### PR TITLE
Team endpoints

### DIFF
--- a/internal/server/matches.go
+++ b/internal/server/matches.go
@@ -44,17 +44,9 @@ func (s *Server) matchesHandler() http.HandlerFunc {
 
 		matches := []match{}
 		for _, fullMatch := range fullMatches {
-			var time *store.UnixTime
-
-			if fullMatch.ActualTime != nil {
-				time = fullMatch.ActualTime
-			} else {
-				time = fullMatch.PredictedTime
-			}
-
 			matches = append(matches, match{
 				Key:          fullMatch.Key,
-				Time:         time,
+				Time:         fullMatch.GetTime(),
 				RedScore:     fullMatch.RedScore,
 				BlueScore:    fullMatch.BlueScore,
 				RedAlliance:  fullMatch.RedAlliance,
@@ -95,16 +87,9 @@ func (s *Server) matchHandler() http.HandlerFunc {
 			return
 		}
 
-		var time *store.UnixTime
-		if fullMatch.ActualTime != nil {
-			time = fullMatch.ActualTime
-		} else {
-			time = fullMatch.PredictedTime
-		}
-
 		match := match{
 			Key:          fullMatch.Key,
-			Time:         time,
+			Time:         fullMatch.GetTime(),
 			RedScore:     fullMatch.RedScore,
 			BlueScore:    fullMatch.BlueScore,
 			RedAlliance:  fullMatch.RedAlliance,

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -10,5 +10,7 @@ func (s *Server) registerRoutes() *mux.Router {
 	r.Handle("/events/{eventKey}/info", s.eventHandler()).Methods("GET")
 	r.Handle("/events/{eventKey}/matches", s.matchesHandler()).Methods("GET")
 	r.Handle("/events/{eventKey}/matches/{matchKey}/info", s.matchHandler()).Methods("GET")
+	r.Handle("/events/{eventKey}/teams", s.teamsHandler()).Methods("GET")
+	r.Handle("/events/{eventKey}/teams/{teamKey}/info", s.teamInfoHandler()).Methods("GET")
 	return r
 }

--- a/internal/server/teams.go
+++ b/internal/server/teams.go
@@ -1,0 +1,111 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/Pigmice2733/peregrine-backend/internal/store"
+	"github.com/gorilla/mux"
+
+	ihttp "github.com/Pigmice2733/peregrine-backend/internal/http"
+)
+
+type team struct {
+	Rank         *int     `json:"rank,omitempty"`
+	RankingScore *float64 `json:"rankingScore,omitempty"`
+}
+
+// teamsHandler returns a handler to get all teams at a given event.
+func (s *Server) teamsHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		eventKey := mux.Vars(r)["eventKey"]
+
+		// Get new team data from TBA
+		if err := s.updateTeamKeys(eventKey); err != nil {
+			// 404 if eventKey isn't a real event
+			if ok := store.IsNoResultError(err); ok {
+				ihttp.Error(w, http.StatusNotFound)
+				return
+			}
+			ihttp.Error(w, http.StatusInternalServerError)
+			s.logger.Printf("Error: updating team key data: %v\n", err)
+			return
+		}
+
+		teamKeys, err := s.store.GetTeamKeys(eventKey)
+		if err != nil {
+			ihttp.Error(w, http.StatusInternalServerError)
+			s.logger.Printf("Error: retrieving team key data: %v\n", err)
+			return
+		}
+
+		ihttp.Respond(w, teamKeys, nil, http.StatusOK)
+	}
+}
+
+// teamInfoHandler returns a handler to get info about a specific team at a specific event.
+func (s *Server) teamInfoHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		eventKey, teamKey := vars["eventKey"], vars["teamKey"]
+
+		// Get new team rankings data from TBA
+		if err := s.updateTeamRankings(eventKey); err != nil {
+			// 404 if eventKey isn't a real event
+			if ok := store.IsNoResultError(err); ok {
+				ihttp.Error(w, http.StatusNotFound)
+				return
+			}
+			ihttp.Error(w, http.StatusInternalServerError)
+			s.logger.Printf("Error: updating team rankings data: %v\n", err)
+			return
+		}
+
+		fullTeam, err := s.store.GetTeam(teamKey, eventKey)
+		if err != nil {
+			if ok := store.IsNoResultError(err); ok {
+				ihttp.Error(w, http.StatusNotFound)
+				return
+			}
+			ihttp.Error(w, http.StatusInternalServerError)
+			s.logger.Printf("Error: retrieving team rankings data: %v\n", err)
+			return
+		}
+
+		team := team{
+			Rank:         fullTeam.Rank,
+			RankingScore: fullTeam.RankingScore,
+		}
+
+		ihttp.Respond(w, team, nil, http.StatusOK)
+	}
+}
+
+// Get new team key data from TBA for a particular event. Upsert data into database.
+func (s *Server) updateTeamKeys(eventKey string) error {
+	// Check that eventKey is a valid event key
+	err := s.store.CheckEventKey(eventKey)
+	if err != nil {
+		return err
+	}
+
+	teams, err := s.tba.GetTeamKeys(eventKey)
+	if err != nil {
+		return err
+	}
+	return s.store.TeamKeysUpsert(eventKey, teams)
+}
+
+// Get new team rankings data from TBA for a particular event. Upsert data into database.
+func (s *Server) updateTeamRankings(eventKey string) error {
+	// Check that eventKey is a valid event key
+	err := s.store.CheckEventKey(eventKey)
+	if err != nil {
+		return err
+	}
+
+	teams, err := s.tba.GetTeamRankings(eventKey)
+	if err != nil {
+		return err
+	}
+	return s.store.TeamsUpsert(teams)
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -60,20 +60,20 @@ func New(o Options) (Service, error) {
 // database drivers and JSON marshallers/unmarshallers but are internally
 // represented as unix timestamps for easier comparison.
 type UnixTime struct {
-	unix int64
+	Unix int64
 }
 
 // NewUnixFromTime creates a new UnixTime timestamp from a time.Time.
 func NewUnixFromTime(time time.Time) UnixTime {
 	return UnixTime{
-		unix: time.Unix(),
+		Unix: time.Unix(),
 	}
 }
 
 // NewUnixFromInt creates a new UnixTime timestamp from an int64.
 func NewUnixFromInt(time int64) UnixTime {
 	return UnixTime{
-		unix: time,
+		Unix: time,
 	}
 }
 
@@ -82,9 +82,9 @@ func NewUnixFromInt(time int64) UnixTime {
 func (ut *UnixTime) Scan(src interface{}) error {
 	switch v := src.(type) {
 	case time.Time:
-		ut.unix = v.Unix()
+		ut.Unix = v.Unix()
 	case int64:
-		ut.unix = v
+		ut.Unix = v
 	default:
 		return fmt.Errorf("got invalid type for time: %T", src)
 	}
@@ -95,12 +95,12 @@ func (ut *UnixTime) Scan(src interface{}) error {
 // Value returns a driver.Value that is always a time.Time that represents the
 // internally stored unix time.
 func (ut *UnixTime) Value() (driver.Value, error) {
-	return time.Unix(ut.unix, 0), nil
+	return time.Unix(ut.Unix, 0), nil
 }
 
 // MarshalJSON returns a []byte that represents this UnixTime in RFC 3339 format.
 func (ut *UnixTime) MarshalJSON() ([]byte, error) {
-	return time.Unix(ut.unix, 0).MarshalJSON()
+	return time.Unix(ut.Unix, 0).MarshalJSON()
 }
 
 // UnmarshalJSON accepts a []byte representing a time.Time value, and unmarshals
@@ -112,7 +112,7 @@ func (ut *UnixTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	ut.unix = time.Unix()
+	ut.Unix = time.Unix()
 
 	return nil
 }

--- a/internal/store/teams.go
+++ b/internal/store/teams.go
@@ -1,0 +1,108 @@
+package store
+
+import (
+	"database/sql"
+)
+
+// Team holds data about a single FRC team at a specific event.
+type Team struct {
+	Key          string
+	EventKey     string
+	Rank         *int
+	RankingScore *float64
+}
+
+// GetTeamKeys retrieves all team keys from an event specified by eventKey.
+func (s *Service) GetTeamKeys(eventKey string) ([]string, error) {
+	rows, err := s.db.Query("SELECT key FROM teams WHERE event_key = $1", eventKey)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	teamKeys := []string{}
+	for rows.Next() {
+		var teamKey string
+		if err := rows.Scan(&teamKey); err != nil {
+			return nil, err
+		}
+		teamKeys = append(teamKeys, teamKey)
+	}
+
+	return teamKeys, rows.Err()
+}
+
+// GetTeam retrieves a team specified by teamKey from a event specified by eventKey.
+func (s *Service) GetTeam(teamKey string, eventKey string) (Team, error) {
+	var rank *int
+	var rankingScore *float64
+	var team Team
+	err := s.db.QueryRow("SELECT rank, ranking_score FROM teams WHERE key = $1 AND event_key = $2", teamKey, eventKey).Scan(&rank, &rankingScore)
+	if err == sql.ErrNoRows {
+		return team, NoResultError{err}
+	}
+	team.Key = teamKey
+	team.EventKey = eventKey
+	team.Rank = rank
+	team.RankingScore = rankingScore
+	return team, err
+}
+
+// TeamKeysUpsert upserts multiple team keys from a single event into the database.
+func (s *Service) TeamKeysUpsert(eventKey string, keys []string) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+
+	stmt, err := tx.Prepare(`
+		INSERT INTO teams (key, event_key)
+		VALUES ($1, $2)
+		ON CONFLICT (key, event_key) DO NOTHING
+	`)
+	if err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	defer stmt.Close()
+
+	for _, key := range keys {
+		if _, err = stmt.Exec(key, eventKey); err != nil {
+			_ = tx.Rollback()
+			return err
+		}
+	}
+
+	return tx.Commit()
+}
+
+// TeamsUpsert upserts multiple teams into the database.
+func (s *Service) TeamsUpsert(teams []Team) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+
+	stmt, err := tx.Prepare(`
+		INSERT INTO teams (key, event_key, rank, ranking_score)
+		VALUES ($1, $2, $3, $4)
+		ON CONFLICT (key, event_key)
+		DO
+			UPDATE
+				SET rank = $3, ranking_score = $4
+	`)
+	if err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	defer stmt.Close()
+
+	for _, team := range teams {
+		if _, err = stmt.Exec(team.Key, team.EventKey, team.Rank, team.RankingScore); err != nil {
+			_ = tx.Rollback()
+			return err
+		}
+	}
+
+	return tx.Commit()
+}

--- a/migrations/4_create_teams_table.down.sql
+++ b/migrations/4_create_teams_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE teams;

--- a/migrations/4_create_teams_table.up.sql
+++ b/migrations/4_create_teams_table.up.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS teams (
+    key TEXT NOT NULL,
+    event_key TEXT NOT NULL REFERENCES events,
+    rank INTEGER,
+    ranking_score REAL,
+
+    PRIMARY KEY(key, event_key)
+)


### PR DESCRIPTION
# Goal

Add teams and team info endpoints.

# Testing

Run API tests, unit tests, make a fake match that starts in the next few minutes for an existing event and check that `events/{eventKey}/teams/{teamKey}/info` has `nextMatch` set to that event.
