### PR TITLE
Change roles type from string array to struct

### DIFF
--- a/etc/config.testing.yaml
+++ b/etc/config.testing.yaml
@@ -8,7 +8,7 @@ tba:
 
 database:
   user: peregrine
-  password:
+  password: ""
   host: localhost
   port: 5432
   name: peregrine
@@ -20,5 +20,5 @@ seedUser:
   firstName: John
   lastName: Doe
   roles:
-    - verified
-    - admin
+    isVerified: true
+    isAdmin: true

--- a/etc/config.yaml.template
+++ b/etc/config.yaml.template
@@ -8,7 +8,7 @@ tba:
 
 database:
     user: postgres
-    password:
+    password: ""
     host: localhost
     port: 5432
     name: peregrine

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,11 +26,11 @@ type Config struct {
 	} `yaml:"tba"`
 
 	SeedUser *struct {
-		Username  string   `yaml:"username"`
-		Password  string   `yaml:"password"`
-		FirstName string   `yaml:"firstName"`
-		LastName  string   `yaml:"lastName"`
-		Roles     []string `yaml:"roles"`
+		Username  string      `yaml:"username"`
+		Password  string      `yaml:"password"`
+		FirstName string      `yaml:"firstName"`
+		LastName  string      `yaml:"lastName"`
+		Roles     store.Roles `yaml:"roles"`
 	} `yaml:"seedUser"`
 
 	Database store.Options `yaml:"database"`

--- a/migrations/4_create_users_table.up.sql
+++ b/migrations/4_create_users_table.up.sql
@@ -4,5 +4,5 @@ CREATE TABLE users (
     hashed_password VARCHAR(255) NOT NULL,
     first_name TEXT NOT NULL,
     last_name TEXT NOT NULL,
-    roles TEXT[]
+    roles JSONB
 )


### PR DESCRIPTION
# Goal
This PR changes `Roles` from a string array to a struct. It still uses JSONB in postgres for roles so we can easily add new roles without having to run. This will break `edge` and `prod` because I didn't use a migration to change the roles type since we're still alpha and there's no DB in the database that actually matters. Closes #42 

# Testing
API tests, play around with the authenticate and register endpoints to make sure everything is still working as expected.
