### PR TITLE
Remove leading event key from match keys sent to frontend

### DIFF
--- a/api-tests/api.test.js
+++ b/api-tests/api.test.js
@@ -182,7 +182,7 @@ test('/events/{eventKey}/matches endpoint', async () => {
 
 test('/events/{eventKey}/matches/{matchKey}/info endpoint', async () => {
   const d = await fetch(
-    addr + '/events/2018flor/matches/2018flor_qm28/info',
+    addr + '/events/2018flor/matches/qm28/info',
   ).then(d => d.json())
   const info = d.data
   expect(info).toBeAMatch()

--- a/internal/server/teams.go
+++ b/internal/server/teams.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/Pigmice2733/peregrine-backend/internal/store"
@@ -102,8 +103,11 @@ func (s *Server) teamInfoHandler() http.HandlerFunc {
 
 		var nextMatch *match
 		if fullNextMatch != nil {
+			// Match keys are stored in TBA format, with leading event key
+			// prefix, which needs to be removed before use.
+			key := strings.TrimPrefix(fullNextMatch.Key, eventKey+"_")
 			nextMatch = &match{
-				Key:          fullNextMatch.Key,
+				Key:          key,
 				Time:         fullNextMatch.GetTime(),
 				RedScore:     fullNextMatch.RedScore,
 				BlueScore:    fullNextMatch.BlueScore,


### PR DESCRIPTION
# Goal

Remove leading event key from match keys sent to frontend. For example, instead of `2018cc_qm2`, the API should respond with just `qm2`.

# Testing

Check that all the routes involving match keys behave as expected, and run the api tests.

Closes #35 
