### PR TITLE
Add scheduledTime to matches for match sorting on the frontend

### DIFF
--- a/api-tests/api.test.js
+++ b/api-tests/api.test.js
@@ -52,7 +52,6 @@ expect.extend({
     try {
       expect(received.key).toBeA(String)
       expect(received.time).toBeADateString()
-      expect(received.scheduledTime).toBeADateString()
       expect(received.redScore).toBeUndefinedOr(Number)
       expect(received.blueScore).toBeUndefinedOr(Number)
       expect(received.redAlliance).toEqual(expect.any(Array))
@@ -235,6 +234,7 @@ test('/events/{eventKey}/matches endpoint', async () => {
   expect(d.data.length).toBeGreaterThan(1)
   d.data.forEach(match => {
     expect(match).toBeAMatch()
+    expect(match.scheduledTime).toBeADateString()
   })
 })
 
@@ -266,10 +266,10 @@ test('/matches create endpoint', async () => {
   ).then(d => d.json())
 
   expect(d.data).toBeAMatch()
+  expect(d.data.scheduledTime).toBeUndefined()
   expect(d.data).toEqual({
     key: match.key,
     time: expect.toEqualDate(match.time),
-    scheduledTime: expect.toEqualDate(match.time),
     redScore: match.redScore,
     blueScore: match.blueScore,
     redAlliance: match.redAlliance,
@@ -282,6 +282,7 @@ test('/events/{eventKey}/matches/{matchKey}/info endpoint', async () => {
     d.json(),
   )
   const info = d.data
+  expect(info.scheduledTime).toBeUndefined()
   expect(info).toBeAMatch()
 })
 
@@ -302,6 +303,7 @@ test('/events/{eventKey}/teams/{teamKey}/info endpoint', async () => {
   expect(info.rankingScore).toBeUndefinedOr(Number)
   expect(info.nextMatch).toBeUndefinedOr(Object)
   if (info.nextMatch !== undefined) {
+    expect(info.nextMatch.scheduledTime).toBeUndefined()
     expect(info.nextMatch).toBeAMatch()
   }
   expect(Object.keys(info)).toBeASubsetOf(['nextMatch', 'rank', 'rankingScore'])

--- a/api-tests/api.test.js
+++ b/api-tests/api.test.js
@@ -52,6 +52,7 @@ expect.extend({
     try {
       expect(received.key).toBeA(String)
       expect(received.time).toBeADateString()
+      expect(received.scheduledTime).toBeADateString()
       expect(received.redScore).toBeUndefinedOr(Number)
       expect(received.blueScore).toBeUndefinedOr(Number)
       expect(received.redAlliance).toEqual(expect.any(Array))
@@ -67,6 +68,7 @@ expect.extend({
       expect(Object.keys(received)).toBeASubsetOf([
         'key',
         'time',
+        'scheduledTime',
         'redAlliance',
         'blueAlliance',
         'redScore',
@@ -263,9 +265,11 @@ test('/matches create endpoint', async () => {
     addr + `/events/2018flor/matches/${match.key}/info`,
   ).then(d => d.json())
 
+  expect(d.data).toBeAMatch()
   expect(d.data).toEqual({
     key: match.key,
     time: expect.toEqualDate(match.time),
+    scheduledTime: expect.toEqualDate(match.time),
     redScore: match.redScore,
     blueScore: match.blueScore,
     redAlliance: match.redAlliance,

--- a/internal/server/matches.go
+++ b/internal/server/matches.go
@@ -15,7 +15,7 @@ import (
 type match struct {
 	Key           string          `json:"key"`
 	Time          *store.UnixTime `json:"time"`
-	ScheduledTime *store.UnixTime `json:"scheduledTime"`
+	ScheduledTime *store.UnixTime `json:"scheduledTime,omitempty"`
 	RedScore      *int            `json:"redScore,omitempty"`
 	BlueScore     *int            `json:"blueScore,omitempty"`
 	RedAlliance   []string        `json:"redAlliance"`
@@ -103,13 +103,12 @@ func (s *Server) matchHandler() http.HandlerFunc {
 		// prefix that which needs to be removed before use.
 		key := strings.TrimPrefix(fullMatch.Key, eventKey+"_")
 		match := match{
-			Key:           key,
-			Time:          fullMatch.GetTime(),
-			ScheduledTime: fullMatch.ScheduledTime,
-			RedScore:      fullMatch.RedScore,
-			BlueScore:     fullMatch.BlueScore,
-			RedAlliance:   fullMatch.RedAlliance,
-			BlueAlliance:  fullMatch.BlueAlliance,
+			Key:          key,
+			Time:         fullMatch.GetTime(),
+			RedScore:     fullMatch.RedScore,
+			BlueScore:    fullMatch.BlueScore,
+			RedAlliance:  fullMatch.RedAlliance,
+			BlueAlliance: fullMatch.BlueAlliance,
 		}
 
 		ihttp.Respond(w, match, http.StatusOK)

--- a/internal/server/matches.go
+++ b/internal/server/matches.go
@@ -13,12 +13,13 @@ import (
 )
 
 type match struct {
-	Key          string          `json:"key"`
-	Time         *store.UnixTime `json:"time"`
-	RedScore     *int            `json:"redScore,omitempty"`
-	BlueScore    *int            `json:"blueScore,omitempty"`
-	RedAlliance  []string        `json:"redAlliance"`
-	BlueAlliance []string        `json:"blueAlliance"`
+	Key           string          `json:"key"`
+	Time          *store.UnixTime `json:"time"`
+	ScheduledTime *store.UnixTime `json:"scheduledTime"`
+	RedScore      *int            `json:"redScore,omitempty"`
+	BlueScore     *int            `json:"blueScore,omitempty"`
+	RedAlliance   []string        `json:"redAlliance"`
+	BlueAlliance  []string        `json:"blueAlliance"`
 }
 
 // matchesHandler returns a handler to get all matches at a given event.
@@ -51,12 +52,13 @@ func (s *Server) matchesHandler() http.HandlerFunc {
 			// prefix that which needs to be removed before use.
 			key := strings.TrimPrefix(fullMatch.Key, eventKey+"_")
 			matches = append(matches, match{
-				Key:          key,
-				Time:         fullMatch.GetTime(),
-				RedScore:     fullMatch.RedScore,
-				BlueScore:    fullMatch.BlueScore,
-				RedAlliance:  fullMatch.RedAlliance,
-				BlueAlliance: fullMatch.BlueAlliance,
+				Key:           key,
+				Time:          fullMatch.GetTime(),
+				ScheduledTime: fullMatch.ScheduledTime,
+				RedScore:      fullMatch.RedScore,
+				BlueScore:     fullMatch.BlueScore,
+				RedAlliance:   fullMatch.RedAlliance,
+				BlueAlliance:  fullMatch.BlueAlliance,
 			})
 		}
 
@@ -101,12 +103,13 @@ func (s *Server) matchHandler() http.HandlerFunc {
 		// prefix that which needs to be removed before use.
 		key := strings.TrimPrefix(fullMatch.Key, eventKey+"_")
 		match := match{
-			Key:          key,
-			Time:         fullMatch.GetTime(),
-			RedScore:     fullMatch.RedScore,
-			BlueScore:    fullMatch.BlueScore,
-			RedAlliance:  fullMatch.RedAlliance,
-			BlueAlliance: fullMatch.BlueAlliance,
+			Key:           key,
+			Time:          fullMatch.GetTime(),
+			ScheduledTime: fullMatch.ScheduledTime,
+			RedScore:      fullMatch.RedScore,
+			BlueScore:     fullMatch.BlueScore,
+			RedAlliance:   fullMatch.RedAlliance,
+			BlueAlliance:  fullMatch.BlueAlliance,
 		}
 
 		ihttp.Respond(w, match, http.StatusOK)
@@ -134,13 +137,14 @@ func (s *Server) createMatchHandler() http.HandlerFunc {
 		}
 
 		sm := store.Match{
-			Key:          m.Key,
-			EventKey:     eventKey,
-			ActualTime:   m.Time,
-			RedScore:     m.RedScore,
-			BlueScore:    m.BlueScore,
-			RedAlliance:  m.RedAlliance,
-			BlueAlliance: m.BlueAlliance,
+			Key:           m.Key,
+			EventKey:      eventKey,
+			ActualTime:    m.Time,
+			ScheduledTime: m.Time,
+			RedScore:      m.RedScore,
+			BlueScore:     m.BlueScore,
+			RedAlliance:   m.RedAlliance,
+			BlueAlliance:  m.BlueAlliance,
 		}
 
 		if err := s.store.MatchesUpsert([]store.Match{sm}); err != nil {

--- a/internal/store/matches.go
+++ b/internal/store/matches.go
@@ -10,6 +10,7 @@ type Match struct {
 	EventKey      string    `json:"eventKey"`
 	PredictedTime *UnixTime `json:"predictedTime"`
 	ActualTime    *UnixTime `json:"actualTime"`
+	ScheduledTime *UnixTime `json:"scheduledTime"`
 	RedScore      *int      `json:"redScore"`
 	BlueScore     *int      `json:"blueScore"`
 	RedAlliance   []string  `json:"redAlliance"`
@@ -21,21 +22,28 @@ func (m *Match) GetTime() *UnixTime {
 	if m.ActualTime != nil {
 		return m.ActualTime
 	}
-	return m.PredictedTime
+	if m.PredictedTime != nil {
+		return m.PredictedTime
+	}
+	return m.ScheduledTime
 }
 
-// GetEventMatches returns all matches from a specfic event.
+// GetEventMatches returns all matches from a specfic event. The matches are sorted by ScheduledTime, in increasing order.
 func (s *Service) GetEventMatches(eventKey string) ([]Match, error) {
 	var matches []Match
-	rows, err := s.db.Query("SELECT key, predicted_time, actual_time, red_score, blue_score FROM matches WHERE event_key = $1", eventKey)
+	rows, err := s.db.Query(`
+	    SELECT
+            key, predicted_time, scheduled_time, actual_time, red_score, blue_score
+		FROM matches
+		WHERE event_key = $1`, eventKey)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
 
 	for rows.Next() {
-		match := Match{EventKey: eventKey, PredictedTime: &UnixTime{}, ActualTime: &UnixTime{}}
-		if err := rows.Scan(&match.Key, &match.PredictedTime, &match.ActualTime, &match.RedScore, &match.BlueScore); err != nil {
+		match := Match{EventKey: eventKey, PredictedTime: &UnixTime{}, ActualTime: &UnixTime{}, ScheduledTime: &UnixTime{}}
+		if err := rows.Scan(&match.Key, &match.PredictedTime, &match.ScheduledTime, &match.ActualTime, &match.RedScore, &match.BlueScore); err != nil {
 			return nil, err
 		}
 
@@ -58,7 +66,7 @@ func (s *Service) GetTeamMatches(eventKey string, teamKey string) ([]Match, erro
 	var matches []Match
 	rows, err := s.db.Query(`
 		SELECT
-		    key, predicted_time, actual_time, red_score, blue_score
+		    key, predicted_time, scheduled_time, actual_time, red_score, blue_score
 		FROM matches
 		INNER JOIN alliances
 			ON matches.key = alliances.match_key
@@ -69,8 +77,8 @@ func (s *Service) GetTeamMatches(eventKey string, teamKey string) ([]Match, erro
 	defer rows.Close()
 
 	for rows.Next() {
-		match := Match{EventKey: eventKey, PredictedTime: &UnixTime{}, ActualTime: &UnixTime{}}
-		if err := rows.Scan(&match.Key, &match.PredictedTime, &match.ActualTime, &match.RedScore, &match.BlueScore); err != nil {
+		match := Match{EventKey: eventKey, PredictedTime: &UnixTime{}, ActualTime: &UnixTime{}, ScheduledTime: &UnixTime{}}
+		if err := rows.Scan(&match.Key, &match.PredictedTime, &match.ScheduledTime, &match.ActualTime, &match.RedScore, &match.BlueScore); err != nil {
 			return nil, err
 		}
 
@@ -91,9 +99,9 @@ func (s *Service) GetTeamMatches(eventKey string, teamKey string) ([]Match, erro
 // GetMatch returns a specfic match.
 func (s *Service) GetMatch(matchKey string) (Match, error) {
 	var redScore, blueScore *int
-	match := Match{Key: matchKey, PredictedTime: &UnixTime{}, ActualTime: &UnixTime{}}
-	if err := s.db.QueryRow("SELECT event_key, predicted_time, actual_time, red_score, blue_score FROM matches WHERE key = $1", matchKey).
-		Scan(&match.EventKey, &match.PredictedTime, &match.ActualTime, &redScore, &blueScore); err != nil {
+	match := Match{Key: matchKey, PredictedTime: &UnixTime{}, ActualTime: &UnixTime{}, ScheduledTime: &UnixTime{}}
+	if err := s.db.QueryRow("SELECT event_key, predicted_time, scheduled_time, actual_time, red_score, blue_score FROM matches WHERE key = $1", matchKey).
+		Scan(&match.EventKey, &match.PredictedTime, &match.ScheduledTime, &match.ActualTime, &redScore, &blueScore); err != nil {
 		if err == sql.ErrNoRows {
 			return match, ErrNoResults(err)
 		}
@@ -120,12 +128,12 @@ func (s *Service) MatchesUpsert(matches []Match) error {
 	}
 
 	stmt, err := tx.Prepare(`
-		INSERT INTO matches (key, event_key, predicted_time, actual_time, red_score, blue_score)
-		VALUES ($1, $2, $3, $4, $5, $6)
+		INSERT INTO matches (key, event_key, predicted_time, scheduled_time, actual_time, red_score, blue_score)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
 		ON CONFLICT (key)
 		DO
 			UPDATE
-				SET event_key = $2, predicted_time = $3, actual_time = $4, red_score = $5, blue_score = $6
+				SET event_key = $2, predicted_time = $3, scheduled_time = $4, actual_time = $5, red_score = $6, blue_score = $7
 	`)
 	if err != nil {
 		_ = tx.Rollback()
@@ -134,7 +142,7 @@ func (s *Service) MatchesUpsert(matches []Match) error {
 	defer stmt.Close()
 
 	for _, match := range matches {
-		if _, err = stmt.Exec(match.Key, match.EventKey, match.PredictedTime, match.ActualTime, match.RedScore, match.BlueScore); err != nil {
+		if _, err = stmt.Exec(match.Key, match.EventKey, match.PredictedTime, match.ScheduledTime, match.ActualTime, match.RedScore, match.BlueScore); err != nil {
 			_ = tx.Rollback()
 			return err
 		}

--- a/internal/store/matches.go
+++ b/internal/store/matches.go
@@ -28,7 +28,7 @@ func (m *Match) GetTime() *UnixTime {
 	return m.ScheduledTime
 }
 
-// GetEventMatches returns all matches from a specfic event. The matches are sorted by ScheduledTime, in increasing order.
+// GetEventMatches returns all matches from a specfic event.
 func (s *Service) GetEventMatches(eventKey string) ([]Match, error) {
 	var matches []Match
 	rows, err := s.db.Query(`

--- a/internal/tba/tba.go
+++ b/internal/tba/tba.go
@@ -50,6 +50,7 @@ type match struct {
 	Key           string `json:"key"`
 	PredictedTime int64  `json:"predicted_time"`
 	ActualTime    int64  `json:"actual_time"`
+	ScheduledTime int64  `json:"time"`
 	Alliances     struct {
 		Red  alliance `json:"red"`
 		Blue alliance `json:"blue"`
@@ -195,6 +196,7 @@ func (s *Service) GetMatches(eventKey string) ([]store.Match, error) {
 	for _, tbaMatch := range tbaMatches {
 		var predictedTime *store.UnixTime
 		var actualTime *store.UnixTime
+		var scheduledTime *store.UnixTime
 
 		if tbaMatch.PredictedTime != 0 {
 			timestamp := store.NewUnixFromInt(tbaMatch.PredictedTime)
@@ -204,6 +206,11 @@ func (s *Service) GetMatches(eventKey string) ([]store.Match, error) {
 		if tbaMatch.ActualTime != 0 {
 			timestamp := store.NewUnixFromInt(int64(tbaMatch.ActualTime))
 			actualTime = &timestamp
+		}
+
+		if tbaMatch.ScheduledTime != 0 {
+			timestamp := store.NewUnixFromInt(int64(tbaMatch.ScheduledTime))
+			scheduledTime = &timestamp
 		}
 
 		var redScore, blueScore *int
@@ -219,6 +226,7 @@ func (s *Service) GetMatches(eventKey string) ([]store.Match, error) {
 			EventKey:      eventKey,
 			PredictedTime: predictedTime,
 			ActualTime:    actualTime,
+			ScheduledTime: scheduledTime,
 			RedScore:      redScore,
 			BlueScore:     blueScore,
 			RedAlliance:   tbaMatch.Alliances.Red.TeamKeys,

--- a/internal/tba/tba_test.go
+++ b/internal/tba/tba_test.go
@@ -293,6 +293,7 @@ func TestGetMatches(t *testing.T) {
 							}
 						},
 						"predicted_time": 1520272800,
+						"time": 1520272800,
 						"actual_time": 1520274000
 					},
 					{
@@ -308,6 +309,7 @@ func TestGetMatches(t *testing.T) {
 							}
 						},
 						"predicted_time": 1525272780,
+						"time": 1525272780,
 						"actual_time": 1525273980
 					}
 				]
@@ -323,6 +325,7 @@ func TestGetMatches(t *testing.T) {
 					Key:           "key1",
 					EventKey:      "2018alhu",
 					PredictedTime: newUnixTime(time.Date(2018, 3, 5, 18, 0, 0, 0, time.UTC)),
+					ScheduledTime: newUnixTime(time.Date(2018, 3, 5, 18, 0, 0, 0, time.UTC)),
 					ActualTime:    newUnixTime(time.Date(2018, 3, 5, 18, 20, 0, 0, time.UTC)),
 					RedScore:      newInt(220),
 					BlueScore:     newInt(500),
@@ -333,6 +336,7 @@ func TestGetMatches(t *testing.T) {
 					Key:           "key2",
 					EventKey:      "2018alhu",
 					PredictedTime: newUnixTime(time.Date(2018, 5, 2, 14, 53, 0, 0, time.UTC)),
+					ScheduledTime: newUnixTime(time.Date(2018, 5, 2, 14, 53, 0, 0, time.UTC)),
 					ActualTime:    newUnixTime(time.Date(2018, 5, 2, 15, 13, 0, 0, time.UTC)),
 					RedScore:      newInt(120),
 					BlueScore:     newInt(600),
@@ -364,6 +368,7 @@ func TestGetMatches(t *testing.T) {
 							}
 						},
 						"predicted_time": 1520272800,
+						"time": 1520272800,
 						"actual_time": 1520274000
 					},
 					{
@@ -378,7 +383,8 @@ func TestGetMatches(t *testing.T) {
 								"team_keys": ["frc2", "frc7", "frc3"]
 							}
 						},
-						"predicted_time": 1525272780,
+						"predicted_time": null,
+						"time": 1525272780,
 						"actual_time": null
 					}
 				]
@@ -394,6 +400,7 @@ func TestGetMatches(t *testing.T) {
 					Key:           "key1",
 					EventKey:      "2018alhu",
 					PredictedTime: newUnixTime(time.Date(2018, 3, 5, 18, 0, 0, 0, time.UTC)),
+					ScheduledTime: newUnixTime(time.Date(2018, 3, 5, 18, 0, 0, 0, time.UTC)),
 					ActualTime:    newUnixTime(time.Date(2018, 3, 5, 18, 20, 0, 0, time.UTC)),
 					RedScore:      nil,
 					BlueScore:     nil,
@@ -403,7 +410,8 @@ func TestGetMatches(t *testing.T) {
 				{
 					Key:           "key2",
 					EventKey:      "2018alhu",
-					PredictedTime: newUnixTime(time.Date(2018, 5, 2, 14, 53, 0, 0, time.UTC)),
+					PredictedTime: nil,
+					ScheduledTime: newUnixTime(time.Date(2018, 5, 2, 14, 53, 0, 0, time.UTC)),
 					ActualTime:    nil,
 					RedScore:      nil,
 					BlueScore:     nil,

--- a/migrations/8_add_scheduled_match_time.down.sql
+++ b/migrations/8_add_scheduled_match_time.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE matches DROP COLUMN scheduled_time;

--- a/migrations/8_add_scheduled_match_time.up.sql
+++ b/migrations/8_add_scheduled_match_time.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE matches ADD COLUMN scheduled_time TIMESTAMPTZ;


### PR DESCRIPTION
# Goal

Add scheduledTime to matches for match sorting on the frontend.

# Testing

Run API tests, check routes to make sure scheduledTime where the docs says it does.

Closes #56 

