### PR TITLE
Fix database connection leak in health handler

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -118,7 +118,7 @@ type status struct {
 func (s *Server) healthHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		tbaHealthy := s.tba.Ping() == nil
-		pgHappy := s.store.Ping() == nil
+		pgHealthy := s.store.Ping() == nil
 
 		ihttp.Respond(w, status{
 			Listen: listen{
@@ -127,9 +127,9 @@ func (s *Server) healthHandler() http.HandlerFunc {
 			},
 			Services: services{
 				TBA:        tbaHealthy,
-				PostgreSQL: pgHappy,
+				PostgreSQL: pgHealthy,
 			},
-			Ok: tbaHealthy && pgHappy,
+			Ok: tbaHealthy && pgHealthy,
 		}, http.StatusOK)
 	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -47,7 +47,8 @@ func New(o Options) (Service, error) {
 // db.Ping() here, but that doesn't actually Ping the database because reasons.
 func (s *Service) Ping() error {
 	if s.db != nil {
-		_, err := s.db.Query("SELECT 1")
+		var alive bool
+		err := s.db.QueryRow("SELECT 1").Scan(&alive)
 		return err
 	}
 

--- a/internal/store/users.go
+++ b/internal/store/users.go
@@ -56,7 +56,7 @@ func (s *Service) GetUser(username string) (User, error) {
 
 // CreateUser creates a given user.
 func (s *Service) CreateUser(u User) error {
-	_, err := s.db.NamedQuery(`
+	_, err := s.db.NamedExec(`
 	INSERT
 		INTO
 			users (username, hashed_password, first_name, last_name, roles)


### PR DESCRIPTION
# Goal
Closes #68 
<!-- Description of what the PR is trying to accomplish. -->

# Testing
Log `s.db.Stats().OpenConnections` while running the tests. Before, each time the health handler was called it went up by one. It should stay at just one connection now.
<!-- Description of how the PR should be tested. -->

