### PR TITLE
Add stricter ACLs for user management endpoints

### DIFF
--- a/api-tests/api.test.js
+++ b/api-tests/api.test.js
@@ -333,7 +333,12 @@ describe('users crud endpoints', () => {
   })
 
   test('/users get route', async () => {
-    const resp = await fetch(addr + '/users')
+    const resp = await fetch(addr + '/users', {
+      headers: {
+        'Content-Type': 'application/json',
+        Authentication: 'Bearer ' + (await getJWT()),
+      },
+    })
     expect(resp.status).toBe(200)
 
     const d = await resp.json()
@@ -346,8 +351,18 @@ describe('users crud endpoints', () => {
     user = Object.assign(user, foundUser)
   })
 
+  test('/users get route unauthorized', async () => {
+    const resp = await fetch(addr + '/users')
+    expect(resp.status).toBe(403)
+  })
+
   test('/users/{id} get route', async () => {
-    const resp = await fetch(addr + '/users/' + user.id)
+    const resp = await fetch(addr + '/users/' + user.id, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authentication: 'Bearer ' + (await getJWT()),
+      },
+    })
     expect(resp.status).toBe(200)
 
     const d = await resp.json()
@@ -362,6 +377,12 @@ describe('users crud endpoints', () => {
     })
   })
 
+  test('/users/{id} get route unauthorized', async () => {
+    const resp = await fetch(addr + '/users/' + user.id)
+
+    expect(resp.status).toBe(403)
+  })
+
   test('/users/{id} complete admin patch route', async () => {
     const patchUser = {
       id: user.id,
@@ -369,7 +390,7 @@ describe('users crud endpoints', () => {
       password: user.password + 'b',
       firstName: user.firstName + 'bar',
       lastName: user.lastName + 'foo',
-      stars: (user.stars || []).concat('2018flor_qm28'),
+      stars: (user.stars || []).concat('2018flor'),
       roles: {},
     }
     patchUser.roles.isAdmin = !(user.roles.isAdmin || true)
@@ -406,6 +427,27 @@ describe('users crud endpoints', () => {
     expect(resp.status).toBe(204)
 
     user = Object.assign(user, patchUser)
+  })
+
+  test('/users/{id} get self route', async () => {
+    const resp = await fetch(addr + '/users/' + user.id, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authentication: 'Bearer ' + (await getJWT(user)),
+      },
+    })
+    expect(resp.status).toBe(200)
+
+    const d = await resp.json()
+
+    expect(d.data).toEqual({
+      id: user.id,
+      username: user.username,
+      firstName: user.firstName,
+      lastName: user.lastName,
+      stars: user.stars,
+      roles: { ...user.roles, isAdmin: false },
+    })
   })
 
   test('/users/{id} complete self patch route', async () => {

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -12,7 +12,7 @@ func (s *Server) registerRoutes() *mux.Router {
 
 	r.Handle("/authenticate", s.authenticateHandler()).Methods("POST")
 	r.Handle("/users", ihttp.ACL(s.createUserHandler(), true, false)).Methods("POST")
-	r.Handle("/users", s.getUsersHandler()).Methods("GET")
+	r.Handle("/users", ihttp.ACL(s.getUsersHandler(), true, true)).Methods("GET")
 	r.Handle("/users/{id}", s.getUserByIDHandler()).Methods("GET")
 	r.Handle("/users/{id}", s.patchUserHandler()).Methods("PATCH")
 

--- a/internal/server/users.go
+++ b/internal/server/users.go
@@ -148,6 +148,19 @@ func (s *Server) getUserByIDHandler() http.HandlerFunc {
 			return
 		}
 
+		sub, err := ihttp.GetSubject(r)
+		if err != nil {
+			ihttp.Error(w, http.StatusForbidden)
+			return
+		}
+
+		// if the user is not an admin and their id does not equal the id they
+		// are trying to get, they are forbidden
+		if !ihttp.GetRoles(r).IsAdmin && sub != id {
+			ihttp.Error(w, http.StatusForbidden)
+			return
+		}
+
 		user, err := s.store.GetUserByID(id)
 		if _, ok := err.(store.ErrNoResults); ok {
 			ihttp.Error(w, http.StatusNotFound)
@@ -203,7 +216,7 @@ func (s *Server) patchUserHandler() http.HandlerFunc {
 			return
 		}
 
-		u := store.PatchUser{ID: id, Username: ru.Username, Roles: ru.Roles, FirstName: ru.FirstName, LastName: ru.LastName}
+		u := store.PatchUser{ID: id, Username: ru.Username, Roles: ru.Roles, FirstName: ru.FirstName, LastName: ru.LastName, Stars: ru.Stars}
 
 		if ru.Password != nil {
 			hashedPassword, err := bcrypt.GenerateFromPassword([]byte(*ru.Password), bcrypt.DefaultCost)


### PR DESCRIPTION
# Goal
Stricter ACL stuff for user management endpoints.

# Testing
JEST
<!-- Description of how the PR should be tested. -->

https://github.com/Pigmice2733/peregrine-frontend/pull/125