### PR TITLE
Fix team filter and use JOINs for getting match alliances

### DIFF
--- a/api-tests/api.test.js
+++ b/api-tests/api.test.js
@@ -207,6 +207,24 @@ describe('match endpoints', () => {
     })
   })
 
+  test('/events/{eventKey}/matches endpoint with filter for multiple teams on opposite alliances', async () => {
+    const resp = await fetch(
+      addr + '/events/2018flor/matches?team=frc180&team=frc1902',
+    )
+    expect(resp.status).toBe(200)
+
+    const d = await resp.json()
+
+    expect(d).toEqual({ data: expect.any(Array) })
+    expect(d.data.length).toBeGreaterThan(2)
+    d.data.forEach(match => {
+      expect(match).toBeAMatch()
+      expect(match.scheduledTime).toBeADateString()
+      expect(match).toIncludeTeam('frc180')
+      expect(match).toIncludeTeam('frc1902')
+    })
+  })
+
   test('/matches create endpoint', async () => {
     expect(config.seedUser.roles.isAdmin).toBe(true)
 

--- a/internal/store/alliances.go
+++ b/internal/store/alliances.go
@@ -1,24 +1,9 @@
 package store
 
 import (
-	"database/sql"
-
 	"github.com/jmoiron/sqlx"
 	"github.com/lib/pq"
 )
-
-// GetMatchAlliance returns a alliance from a specific match. matchKey is the
-// key of the match to get the alliance from, getBlue is a boolean indicating
-// whether to get the blue alliance. If getBlue is false, the red alliance will
-// be retrieved instead.
-func (s *Service) GetMatchAlliance(matchKey string, getBlue bool) ([]string, error) {
-	alliance := []string{}
-	err := s.db.QueryRow("SELECT team_keys FROM alliances WHERE match_key = $1 AND is_blue = $2", matchKey, getBlue).Scan(pq.Array(&alliance))
-	if err == sql.ErrNoRows {
-		return alliance, ErrNoResults(err)
-	}
-	return alliance, err
-}
 
 // AlliancesUpsert upserts the red and blue alliances for a specific match.
 // matchKey is the key of the match. Upsert done within transaction.


### PR DESCRIPTION
# Goal
The `match` store functions now use JOINs rather than seperate statements for getting match alliances, and I also fixed an issue with the team filter where it was checking for teams on an individual alliance row (red OR blue), not for teams in the match as a whole (red AND blue).
<!-- Description of what the PR is trying to accomplish. -->

# Testing
Jest!
<!-- Description of how the PR should be tested. -->

