### PR TITLE
Add context to server.Run()

### DIFF
--- a/cmd/peregrine/main.go
+++ b/cmd/peregrine/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/rand"
 	"flag"
 	"fmt"
@@ -85,5 +86,5 @@ func run(basePath string) error {
 		JWTSecret: jwtSecret,
 	}
 
-	return errors.Wrap(s.Run(), "running server")
+	return errors.Wrap(s.Run(context.Background()), "running server")
 }

--- a/cmd/peregrine/main.go
+++ b/cmd/peregrine/main.go
@@ -43,6 +43,7 @@ func run(basePath string) error {
 	if err != nil {
 		return errors.Wrap(err, "opening postgres server")
 	}
+	defer sto.Close()
 
 	if c.SeedUser != nil {
 		hashedPassword, err := bcrypt.GenerateFromPassword([]byte(c.SeedUser.Password), bcrypt.DefaultCost)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -73,12 +73,12 @@ func (s *Server) Run(ctx context.Context) error {
 		}()
 	}
 
-	go func() {
-		<-ctx.Done()
-		errs <- nil
-	}()
-
-	return <-errs
+	select {
+	case err := <-errs:
+		return err
+	case <-ctx.Done():
+		return nil
+	}
 }
 
 type listen struct {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -47,12 +47,19 @@ func New(o Options) (Service, error) {
 // db.Ping() here, but that doesn't actually Ping the database because reasons.
 func (s *Service) Ping() error {
 	if s.db != nil {
-		var alive bool
-		err := s.db.QueryRow("SELECT 1").Scan(&alive)
-		return err
+		return s.db.QueryRow("SELECT 1").Scan(new(bool))
 	}
 
 	return fmt.Errorf("not connected to postgresql")
+}
+
+// Close closes the underlying postgresql database.
+func (s *Service) Close() error {
+	if s.db != nil {
+		return s.db.Close()
+	}
+
+	return nil
 }
 
 // UnixTime exists so that we can have times that look like time.Time's to


### PR DESCRIPTION
# Goal
Adds context to server.Run() in case we want to stop the server via WithCancel.
