### PR TITLE
Add docker for development

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ jobs:
       - run: go build -o migrate cmd/migrate/main.go
       - run: go build -o peregrine cmd/peregrine/main.go
       - run: ./migrate -up
+      - run: ./migrate -up -migrationsTable seedmigrations -migrationsPath seed-migrations
       - run:
           command: ./peregrine
           background: true

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 /.vscode
 /etc/config*.yaml
 !/etc/config.testing.yaml
+!/etc/config.docker.yaml
 *.exe

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:latest
+
+WORKDIR /go/src/github.com/Pigmice2733/peregrine-backend
+COPY . .
+
+RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+RUN dep ensure -vendor-only
+RUN go get github.com/canthefason/go-watcher
+RUN go install github.com/canthefason/go-watcher/cmd/watcher
+RUN go install ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
-FROM golang:alpine
+FROM golang
 
 WORKDIR /go/src/github.com/Pigmice2733/peregrine-backend
 COPY . .
-
-RUN apk add inotify-tools curl git
 
 RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 RUN dep ensure -vendor-only

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:latest
+FROM golang:alpine
 
 WORKDIR /go/src/github.com/Pigmice2733/peregrine-backend
 COPY . .
 
+RUN apk add inotify-tools curl git
+
 RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 RUN dep ensure -vendor-only
-RUN go get github.com/canthefason/go-watcher
-RUN go install github.com/canthefason/go-watcher/cmd/watcher
 RUN go install ./...

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,172 +2,126 @@
 
 
 [[projects]]
-  digest = "1:0803645e1f57fb5271a6edc7570b9ea59bac2e5de67957075a43f3d74c8dbd97"
   name = "github.com/NYTimes/gziphandler"
   packages = ["."]
-  pruneopts = "UT"
   revision = "2600fb119af974220d3916a5916d6e31176aac1b"
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:76dc72490af7174349349838f2fe118996381b31ea83243812a97e5a0fd5ed55"
   name = "github.com/dgrijalva/jwt-go"
   packages = ["."]
-  pruneopts = "UT"
   revision = "06ea1031745cb8b3dab3f6a236daf2b0aa468b7e"
   version = "v3.2.0"
 
 [[projects]]
-  digest = "1:e1ff887e232b2d8f4f7c7db15a5fac7be418025afc4dda53c59c765dbb5aa6b4"
   name = "github.com/go-playground/locales"
   packages = [
     ".",
-    "currency",
+    "currency"
   ]
-  pruneopts = "UT"
   revision = "f63010822830b6fe52288ee52d5a1151088ce039"
   version = "v0.12.1"
 
 [[projects]]
-  digest = "1:e022cf244bcac1b6ef933f1a2e0adcf6a6dfd7b872d8d41e4d4179bb09a87cbc"
   name = "github.com/go-playground/universal-translator"
   packages = ["."]
-  pruneopts = "UT"
   revision = "b32fa301c9fe55953584134cb6853a13c87ec0a1"
   version = "v0.16.0"
 
 [[projects]]
-  digest = "1:d11309893a17c6f3d487c09d5be0cb6c023d05453558a6afbb17d44af2fded3b"
   name = "github.com/golang-migrate/migrate"
   packages = [
     ".",
     "database",
     "database/postgres",
     "source",
-    "source/file",
+    "source/file"
   ]
-  pruneopts = "UT"
   revision = "93d53a5ae84d81945eedadfe8f6865530d61d51c"
   version = "v3.5.1"
 
 [[projects]]
-  digest = "1:c79fb010be38a59d657c48c6ba1d003a8aa651fa56b579d959d74573b7dff8e1"
   name = "github.com/gorilla/context"
   packages = ["."]
-  pruneopts = "UT"
   revision = "08b5f424b9271eedf6f9f0ce86cb9396ed337a42"
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:e73f5b0152105f18bc131fba127d9949305c8693f8a762588a82a48f61756f5f"
   name = "github.com/gorilla/mux"
   packages = ["."]
-  pruneopts = "UT"
   revision = "e3702bed27f0d39777b0b37b664b6280e8ef8fbf"
   version = "v1.6.2"
 
 [[projects]]
-  digest = "1:6c41d4f998a03b6604227ccad36edaed6126c397e5d78709ef4814a1145a6757"
   name = "github.com/jmoiron/sqlx"
   packages = [
     ".",
-    "reflectx",
+    "reflectx"
   ]
-  pruneopts = "UT"
   revision = "d161d7a76b5661016ad0b085869f77fd410f3e6a"
   version = "v1.2.0"
 
 [[projects]]
-  digest = "1:0a69a1c0db3591fcefb47f115b224592c8dfa4368b7ba9fae509d5e16cdc95c8"
   name = "github.com/konsorten/go-windows-terminal-sequences"
   packages = ["."]
-  pruneopts = "UT"
   revision = "5c8c8bd35d3832f5d134ae1e1e375b69a4d25242"
   version = "v1.0.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:7cefc4f7f6a411c2598d3344563e4d23fd4e4d88fd1591831fe39cccff41ad28"
   name = "github.com/lib/pq"
   packages = [
     ".",
-    "oid",
+    "oid"
   ]
-  pruneopts = "UT"
   revision = "9eb73efc1fcc404148b56765b0d3f61d9a5ef8ee"
 
 [[projects]]
-  digest = "1:40e195917a951a8bf867cd05de2a46aaf1806c50cf92eebf4c16f78cd196f747"
   name = "github.com/pkg/errors"
   packages = ["."]
-  pruneopts = "UT"
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
 [[projects]]
-  digest = "1:69b1cc331fca23d702bd72f860c6a647afd0aa9fcbc1d0659b1365e26546dd70"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
-  pruneopts = "UT"
   revision = "bcd833dfe83d3cebad139e4a29ed79cb2318bf95"
   version = "v1.2.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:001a4e7a40e50ff2ef32e2556bca50c4f77daa457db3ac6afc8bea9bb2122cfb"
   name = "golang.org/x/crypto"
   packages = [
     "bcrypt",
     "blowfish",
-    "ssh/terminal",
+    "ssh/terminal"
   ]
-  pruneopts = "UT"
   revision = "e3636079e1a4c1f337f212cc5cd2aca108f6c900"
 
 [[projects]]
   branch = "master"
-  digest = "1:417d27a82efb8473554234a282be33d23b0d6adc121e636b55950f913ac071d6"
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows",
+    "windows"
   ]
-  pruneopts = "UT"
   revision = "9b800f95dbbc54abff0acf7ee32d88ba4e328c89"
 
 [[projects]]
-  digest = "1:e2f64cca6e235f32cd4c2f9be9ae0cda1f8608fc6fdb68936e8d10e4e0bb074d"
   name = "gopkg.in/go-playground/validator.v9"
   packages = ["."]
-  pruneopts = "UT"
   revision = "e69e9a28bb62b977fdc58d051f1bb477b7cbe486"
   version = "v9.21.0"
 
 [[projects]]
-  digest = "1:342378ac4dcb378a5448dd723f0784ae519383532f5e70ade24132c4c8693202"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  pruneopts = "UT"
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
   version = "v2.2.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  input-imports = [
-    "github.com/NYTimes/gziphandler",
-    "github.com/dgrijalva/jwt-go",
-    "github.com/golang-migrate/migrate",
-    "github.com/golang-migrate/migrate/database/postgres",
-    "github.com/golang-migrate/migrate/source/file",
-    "github.com/gorilla/mux",
-    "github.com/jmoiron/sqlx",
-    "github.com/lib/pq",
-    "github.com/pkg/errors",
-    "github.com/sirupsen/logrus",
-    "golang.org/x/crypto/bcrypt",
-    "gopkg.in/go-playground/validator.v9",
-    "gopkg.in/yaml.v2",
-  ]
+  inputs-digest = "cecb8728f66ee95325fbe958f540a35f204ea21a9c1332e080488e3dfbcd9cae"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -14,6 +14,12 @@
   version = "v3.2.0"
 
 [[projects]]
+  name = "github.com/fsnotify/fsnotify"
+  packages = ["."]
+  revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
+  version = "v1.4.7"
+
+[[projects]]
   name = "github.com/go-playground/locales"
   packages = [
     ".",
@@ -37,8 +43,8 @@
     "source",
     "source/file"
   ]
-  revision = "93d53a5ae84d81945eedadfe8f6865530d61d51c"
-  version = "v3.5.1"
+  revision = "4937cd088f7c7193ee59b319c1c2caa7482aae8e"
+  version = "v3.5.4"
 
 [[projects]]
   name = "github.com/gorilla/context"
@@ -51,6 +57,23 @@
   packages = ["."]
   revision = "e3702bed27f0d39777b0b37b664b6280e8ef8fbf"
   version = "v1.6.2"
+
+[[projects]]
+  name = "github.com/hashicorp/hcl"
+  packages = [
+    ".",
+    "hcl/ast",
+    "hcl/parser",
+    "hcl/printer",
+    "hcl/scanner",
+    "hcl/strconv",
+    "hcl/token",
+    "json/parser",
+    "json/scanner",
+    "json/token"
+  ]
+  revision = "8cb6e5b959231cc1119e43259c4a608f9c51a241"
+  version = "v1.0.0"
 
 [[projects]]
   name = "github.com/jmoiron/sqlx"
@@ -68,13 +91,31 @@
   version = "v1.0.1"
 
 [[projects]]
-  branch = "master"
   name = "github.com/lib/pq"
   packages = [
     ".",
     "oid"
   ]
-  revision = "9eb73efc1fcc404148b56765b0d3f61d9a5ef8ee"
+  revision = "4ded0e9383f75c197b3a2aaa6d590ac52df6fd79"
+  version = "v1.0.0"
+
+[[projects]]
+  name = "github.com/magiconair/properties"
+  packages = ["."]
+  revision = "c2353362d570a7bfa228149c62842019201cfb71"
+  version = "v1.8.0"
+
+[[projects]]
+  name = "github.com/mitchellh/mapstructure"
+  packages = ["."]
+  revision = "3536a929edddb9a5b34bd6861dc4a9647cb459fe"
+  version = "v1.1.2"
+
+[[projects]]
+  name = "github.com/pelletier/go-toml"
+  packages = ["."]
+  revision = "c01d1270ff3e442a8a57cddc1c92dc1138598194"
+  version = "v1.2.0"
 
 [[projects]]
   name = "github.com/pkg/errors"
@@ -89,6 +130,39 @@
   version = "v1.2.0"
 
 [[projects]]
+  name = "github.com/spf13/afero"
+  packages = [
+    ".",
+    "mem"
+  ]
+  revision = "d40851caa0d747393da1ffb28f7f9d8b4eeffebd"
+  version = "v1.1.2"
+
+[[projects]]
+  name = "github.com/spf13/cast"
+  packages = ["."]
+  revision = "8c9545af88b134710ab1cd196795e7f2388358d7"
+  version = "v1.3.0"
+
+[[projects]]
+  name = "github.com/spf13/jwalterweatherman"
+  packages = ["."]
+  revision = "4a4406e478ca629068e7768fc33f3f044173c0a6"
+  version = "v1.0.0"
+
+[[projects]]
+  name = "github.com/spf13/pflag"
+  packages = ["."]
+  revision = "298182f68c66c05229eb03ac171abe6e309ee79a"
+  version = "v1.0.3"
+
+[[projects]]
+  name = "github.com/spf13/viper"
+  packages = ["."]
+  revision = "2c12c60302a5a0e62ee102ca9bc996277c2f64f5"
+  version = "v1.2.1"
+
+[[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
   packages = [
@@ -96,7 +170,7 @@
     "blowfish",
     "ssh/terminal"
   ]
-  revision = "e3636079e1a4c1f337f212cc5cd2aca108f6c900"
+  revision = "3d3f9f413869b949e48070b5bc593aa22cc2b8f2"
 
 [[projects]]
   branch = "master"
@@ -105,13 +179,26 @@
     "unix",
     "windows"
   ]
-  revision = "9b800f95dbbc54abff0acf7ee32d88ba4e328c89"
+  revision = "66b7b1311ac80bbafcd2daeef9a5e6e2cd1e2399"
+
+[[projects]]
+  name = "golang.org/x/text"
+  packages = [
+    "internal/gen",
+    "internal/triegen",
+    "internal/ucd",
+    "transform",
+    "unicode/cldr",
+    "unicode/norm"
+  ]
+  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
+  version = "v0.3.0"
 
 [[projects]]
   name = "gopkg.in/go-playground/validator.v9"
   packages = ["."]
-  revision = "e69e9a28bb62b977fdc58d051f1bb477b7cbe486"
-  version = "v9.21.0"
+  revision = "1fa3c8d6336562f0a3f95c73593ee2b57ff4da11"
+  version = "v9.23.0"
 
 [[projects]]
   name = "gopkg.in/yaml.v2"
@@ -122,6 +209,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "cecb8728f66ee95325fbe958f540a35f204ea21a9c1332e080488e3dfbcd9cae"
+  inputs-digest = "282abee1405415725e1b6c9efe7c32bb1e719ddb6dad6b48f9096ff03e33b819"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ There are two ways to get Peregrine runnning for development. You can either run
 2. Go to the [TBA account page](https://www.thebluealliance.com/account) and get a read API key. Set the TBA API key environment variable (you will need to do this each time you close and reopen your terminal):
 
 ```
-export TBA_API_KEY="your-api-key-goes-here"
+export PRGN_TBA_API_KEY="your-api-key-goes-here"
 ```
 
 3. Build the docker image:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ cd $HOME/go/src/github.com/Pigmice2733/peregrine-backend
 
 # Setup
 
-There are two ways to get Peregrine runnning for development. You can either run it in docker (recommended for beginners), or you can run it natively on your machine. If you chose the docker route, stay in this section. Otherwise, go to the native setup section.
+There are two ways to get Peregrine runnning for development. You can either run it in docker (recommended for beginners), or you can run it natively on your machine. If you chose the docker route, stay in this section. Otherwise, go to the [native setup section](#native-setup-not-recommended-for-beginners).
 
 1. [Install Docker](https://docs.docker.com/install/) and start the daemon.
 
@@ -105,7 +105,7 @@ go test ./...
 
 ## Integration (jest) tests
 
-You must have a server running for integration tests. See the setup section.
+You must have a server running for integration tests. See the [setup section](#setup).
 
 1. Go to the api-tests folder:
 
@@ -146,7 +146,7 @@ git add internal/foo/bar.go
 git commit -m "Add the initial report endpoints"
 ```
 
-3. Verify that your tests pass (see the testing section). If they don't then fix them and add a commit.
+3. Verify that your tests pass (see the [testing section](#testing)). If they don't then fix them and add a commit.
 
 4. Push the branch to the remote github repo:
 

--- a/README.md
+++ b/README.md
@@ -42,11 +42,13 @@ A TBA (the blue alliance) API key is needed to fetch events and matches from the
 
 > **NOTE**: These instructions assume that you already have Docker installed. If you do not, you can get more info at [dockers's install guide](https://docs.docker.com/install/).
 
+> **TIP**: If you get an error similar to `got error: opening config: open etc/config.docker.yaml: permission denied`, you may need to run the following command to set selinux to permissive mode: `sudo setenforce 0`.
+
 You can run peregrine-backend in docker for development. While it's a bit slower, it can allow you to get started in just one command. From the base application directory:
 
     docker-compose up
 
-The application will rebuild and restart on changes of any \*.go file. If you want to run new migrations or clear your database, you can do Ctrl+C to kill docker-compose and restart it with the above command.
+The application will rebuild and restart on changes of any \*.go file. If you want to run new migrations or clear your database, you can do Ctrl+C to kill docker-compose and restart it with the above command. By default it will run the server on port 8080.
 
 # Without Docker (development)
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ Pull Peregrine from GitHub:
 
     go get github.com/Pigmice2733/peregrine-backend
 
+The `go get` command will clone the repository to your GOPATH. You can get to the base directory by using cd on Linux:
+
+    cd $GOPATH/src/github.com/Pigmice2733/peregrine-backend
+
+Or in Powershell on Window:
+
+    cd $env:GOPATH/src/github.com/Pigmice2733/peregrine-backend
+
 # Quickstart (development)
 
 ### Configuration
@@ -37,6 +45,8 @@ Pull Peregrine from GitHub:
 A TBA (the blue alliance) API key is needed to fetch events and matches from the blue alliance. You can get one by visiting [the account page](https://www.thebluealliance.com/account). Go to the "Read API Keys" section, write a short description (e.g. "Peregrine Development Instance"), and hit "Add New Key". Then, copy the key in it's entirety, and run the following command:
 
     export TBA_API_KEY="your-api-key-here"
+
+You will need to do this each time you reopen your terminal.
 
 ### Running
 

--- a/README.md
+++ b/README.md
@@ -46,12 +46,6 @@ export TBA_API_KEY="your-api-key-goes-here"
 docker-compose build
 ```
 
-3. Use docker-compose to start the database:
-
-```
-docker-compose up -d db
-```
-
 4. Use docker-compose to start the app:
 
 ```

--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ Or in Powershell on Window:
 
     cd $env:GOPATH/src/github.com/Pigmice2733/peregrine-backend
 
+### Vendoring
+
+> **NOTE**: These instructions assume that you already have dep installed. If you
+> do not, you can get more info at [dep's install guide](https://github.com/golang/dep/blob/master/docs/installation.md).
+
+Install vendored dependencies:
+
+    dep ensure
+
 # Quickstart (development)
 
 ### Configuration
@@ -54,22 +63,14 @@ You will need to do this each time you reopen your terminal.
 
 > **TIP**: If you get an error similar to `got error: opening config: open etc/config.docker.yaml: permission denied`, you may need to run the following command to set selinux to permissive mode: `sudo setenforce 0`.
 
-You can run peregrine-backend in docker for development. While it's a bit slower, it can allow you to get started in just one command. From the base application directory:
+You can run peregrine-backend in docker for development. While it's a bit slower, it can allow you to get started in just a few commands. From the base application directory:
 
+    dep ensure
     docker-compose up
 
 The application will rebuild and restart on changes of any \*.go file. If you want to run new migrations or clear your database, you can do Ctrl+C to kill docker-compose and restart it with the above command. By default it will run the server on port 8080.
 
 # Without Docker (development)
-
-### Vendoring
-
-> **NOTE**: These instructions assume that you already have dep installed. If you
-> do not, you can get more info at [dep's install guide](https://github.com/golang/dep/blob/master/docs/installation.md).
-
-Install vendored dependencies:
-
-    dep ensure
 
 ### Building
 

--- a/README.md
+++ b/README.md
@@ -4,24 +4,23 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/Pigmice2733/peregrine-backend)](https://goreportcard.com/report/github.com/Pigmice2733/peregrine-backend)
 [![GitHub](https://img.shields.io/github/license/Pigmice2733/peregrine-backend.svg)](https://github.com/Pigmice2733/peregrine-backend/blob/master/LICENSE.md)
 
-Peregrine is a REST API server written in Go for scouting and analysis of FIRST Robotics competitions. 
+Peregrine is a REST API server written in Go for scouting and analysis of FIRST Robotics competitions.
 
 # Scouting
 
 ## What's Scouting?
 
-Scouting is when teams observe the behaviors of a team’s robot throughout matches they compete in within an event. When scouting other teams, scouts look for how a robot performs certain actions during a match, the overall functionality of the team's robot, and how efficient the performance of drive teams are. 
+Scouting is when teams observe the behaviors of a team’s robot throughout matches they compete in within an event. When scouting other teams, scouts look for how a robot performs certain actions during a match, the overall functionality of the team's robot, and how efficient the performance of drive teams are.
 
 ## Why Do We Scout?
 
-The most basic reason we scout is that data we receive from scouting assists us in alliance selections, where highly ranked teams select other teams to join their alliance and compete in playoff matches in hopes to exit the event as the finalist winner. The alliance captains, those who choose other robots to join their alliance, rely on scouting data to strategize which teams will complement their robot's abilities in a game. Cooperating well as a team is critical to playoff matches, as not doing so can cost an alliance many points in a match. Before a match, it's helpful for Drive Captains to know which teams they are competing against as well as who is on their alliance. Scouting gives Drive Captains that insight, and they use the data to strategize with other teams on their alliance to win the upcoming match. 
+The most basic reason we scout is that data we receive from scouting assists us in alliance selections, where highly ranked teams select other teams to join their alliance and compete in playoff matches in hopes to exit the event as the finalist winner. The alliance captains, those who choose other robots to join their alliance, rely on scouting data to strategize which teams will complement their robot's abilities in a game. Cooperating well as a team is critical to playoff matches, as not doing so can cost an alliance many points in a match. Before a match, it's helpful for Drive Captains to know which teams they are competing against as well as who is on their alliance. Scouting gives Drive Captains that insight, and they use the data to strategize with other teams on their alliance to win the upcoming match.
 
 ## Why Use a Scouting App?
 
-A scouting app solves many problems found in traditional paper scouting methods. Most FRC teams use a certain, inefficient process to scout matches; while matches are playing, scouts write data onto paper by checking boxes or filling in numbers based on how a robot competed during the match. Afterward, the data is manually entered into a spreadsheet, tending to be disorganized and difficult to interpret. Because manually entering data into a spreadsheet takes up extra time, the process of strategizing for alliance selections is delayed. In addition, a disorderly spreadsheet makes tracking a team's progress throughout an event challenging. Through a scouting app, the process of manually entering data after matches is eliminated, which allows for the pre-alliance selection process to begin much earlier. The data is immediately uploaded to an organized, easy-to-follow spreadsheet, and multiple graphs are created that display a robot's progress during an event. These components allow for Drive Captains to analyze their opponents quickly. 
+A scouting app solves many problems found in traditional paper scouting methods. Most FRC teams use a certain, inefficient process to scout matches; while matches are playing, scouts write data onto paper by checking boxes or filling in numbers based on how a robot competed during the match. Afterward, the data is manually entered into a spreadsheet, tending to be disorganized and difficult to interpret. Because manually entering data into a spreadsheet takes up extra time, the process of strategizing for alliance selections is delayed. In addition, a disorderly spreadsheet makes tracking a team's progress throughout an event challenging. Through a scouting app, the process of manually entering data after matches is eliminated, which allows for the pre-alliance selection process to begin much earlier. The data is immediately uploaded to an organized, easy-to-follow spreadsheet, and multiple graphs are created that display a robot's progress during an event. These components allow for Drive Captains to analyze their opponents quickly.
 
-
-# Setup
+# Initial Setup
 
 ### GOPATH
 
@@ -30,6 +29,26 @@ A scouting app solves many problems found in traditional paper scouting methods.
 Pull Peregrine from GitHub:
 
     go get github.com/Pigmice2733/peregrine-backend
+
+# Quickstart (development)
+
+### Configuration
+
+A TBA (the blue alliance) API key is needed to fetch events and matches from the blue alliance. You can get one by visiting [the account page](https://www.thebluealliance.com/account). Go to the "Read API Keys" section, write a short description (e.g. "Peregrine Development Instance"), and hit "Add New Key". Then, copy the key in it's entirety, and run the following command:
+
+    export TBA_API_KEY="your-api-key-here"
+
+### Running
+
+> **NOTE**: These instructions assume that you already have Docker installed. If you do not, you can get more info at [dockers's install guide](https://docs.docker.com/install/).
+
+You can run peregrine-backend in docker for development. While it's a bit slower, it can allow you to get started in just one command. From the base application directory:
+
+    docker-compose up
+
+The application will rebuild and restart on changes of any \*.go file. If you want to run new migrations or clear your database, you can do Ctrl+C to kill docker-compose and restart it with the above command.
+
+# Without Docker (development)
 
 ### Vendoring
 
@@ -45,7 +64,7 @@ Install vendored dependencies:
     cd cmd/peregrine
     go build
 
-# Database
+## Database
 
 See the postgresql first steps guide here: https://wiki.postgresql.org/wiki/First_steps
 
@@ -59,7 +78,7 @@ Build and run migrate:
     go build
     ./migrate -up -basePath ../..
 
-# Config File
+## Config File
 
 Copy `./etc/config.json.template` to `./etc/config.development.json` as a starting point.
 
@@ -67,20 +86,20 @@ You must set the field `tba.apiKey` to your TBA API key. If you don't have one, 
 You must also configure the `database` section with the credentials and details of the database you are using. If you've just setup postgres the config file will likely work without any modifications.
 If the `TBA_API_KEY` environment variable is set, it will override the one in the config file. This is mostly just used for CI, you shouldn't need to use it in development. To see the full config schema, you can run `go doc "peregrine-backend/internal/config".Config`
 
-# Environment Variables and Flags
+## Environment Variables and Flags
 
 The environment variable `GO_ENV` can be optionally used to choose which config file to use. If it is set to "developement", `./etc/config.development.json` will be used, if "production", then `./etc/config.production.json`, etc.
 
 The flag `-basePath` will set the directory where `/etc/config.{environment}.json` is, and is available for both `peregrine` and `migrate`.
 
-# Running
+## Running
 
 After building:
 
     cd cmd/peregrine
     ./peregrine
 
-# Development
+# Contributing
 
 All new development should be done in a branch named `<description>`
 
@@ -89,16 +108,3 @@ All new development should be done in a branch named `<description>`
 When the feature is complete, tests pass, and you are ready for it to be merged, create a PR.
 
 Pull requests must have at least one approving review (ideally two), and the CircleCI tests must pass.
-
-# Testing
-
-You can run all peregrine-backend unit tests by simply running `go test ./...` in the root project directory. These will be the same tests that CircleCI runs so before you even _think_ about pushing a branch, make sure you've tested it.
-
-You can run API blackbox integration tests by going to the api-tests folder and doing the following:
-
-```
-npm i
-npm test
-```
-
-After the first time, you don't need to do `npm i`, just `npm test`.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ A TBA (the blue alliance) API key is needed to fetch events and matches from the
 
 ### Running
 
-> **NOTE**: These instructions assume that you already have Docker installed. If you do not, you can get more info at [dockers's install guide](https://docs.docker.com/install/).
+> **NOTE**: These instructions assume that you already have Docker installed and have the daemon running. If you do not, you can get more info at [dockers's install guide](https://docs.docker.com/install/).
 
 > **TIP**: If you get an error similar to `got error: opening config: open etc/config.docker.yaml: permission denied`, you may need to run the following command to set selinux to permissive mode: `sudo setenforce 0`.
 

--- a/README.md
+++ b/README.md
@@ -46,13 +46,19 @@ export TBA_API_KEY="your-api-key-goes-here"
 docker-compose build
 ```
 
-3. Use docker-compose to start the app:
+3. Use docker-compose to start the database:
+
+```
+docker-compose up -d db
+```
+
+4. Use docker-compose to start the app:
 
 ```
 docker-compose up
 ```
 
-4. Party! The application will start running on port 8080. You should be able to access the API at http://localhost:8080/. The app will also expose the PostgreSQL database on port 5432.
+5. Party! The application will start running on port 8080. You should be able to access the API at http://localhost:8080/. The app will also expose the PostgreSQL database on port 5432.
 
 # Native Setup (not recommended for beginners)
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ A TBA (the blue alliance) API key is needed to fetch events and matches from the
 
 ### Running
 
-> **NOTE**: These instructions assume that you already have Docker installed and have the daemon running. If you do not, you can get more info at [dockers's install guide](https://docs.docker.com/install/).
+> **NOTE**: These instructions assume that you already have Docker installed and have the daemon running. If you do not, you can get more info at [docker's install guide](https://docs.docker.com/install/).
 
 > **TIP**: If you get an error similar to `got error: opening config: open etc/config.docker.yaml: permission denied`, you may need to run the following command to set selinux to permissive mode: `sudo setenforce 0`.
 

--- a/README.md
+++ b/README.md
@@ -40,15 +40,19 @@ There are two ways to get Peregrine runnning for development. You can either run
 export TBA_API_KEY="your-api-key-goes-here"
 ```
 
+3. Build the docker image:
+
+```
+docker-compose build
+```
+
 3. Use docker-compose to start the app:
 
 ```
 docker-compose up
 ```
 
-> **TIP**: If you get a permissions error with opening your config files or `watch.sh` you may need to set SELinux to permissive mode with: `sudo setenforce 0`.
-
-The application will start running on port 8080. You should be able to access the API at http://localhost:8080/. The app will also expose the PostgreSQL database on port 5432.
+4. Party! The application will start running on port 8080. You should be able to access the API at http://localhost:8080/. The app will also expose the PostgreSQL database on port 5432.
 
 # Native Setup (not recommended for beginners)
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ cd $HOME/go/src/github.com/Pigmice2733/peregrine-backend
 
 There are two ways to get Peregrine runnning for development. You can either run it in docker (recommended for beginners), or you can run it natively on your machine. If you chose the docker route, stay in this section. Otherwise, go to the [native setup section](#native-setup-not-recommended-for-beginners).
 
-1. [Install Docker](https://docs.docker.com/install/) and start the daemon.
+1. [Install Docker](https://docs.docker.com/install/) and start the daemon. Also, install [docker-compose](https://docs.docker.com/compose/install/).
 
 2. Go to the [TBA account page](https://www.thebluealliance.com/account) and get a read API key. Set the TBA API key environment variable (you will need to do this each time you close and reopen your terminal):
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ cd $HOME/go/src/github.com/Pigmice2733/peregrine-backend
 
 # Setup
 
-There are two ways to get Peregrine runnning for development. You can either run it in docker (recommended for beginners), or you can run it natively on your machine. If you chose the docker route, stay in this section. Otherwise, go to the [native setup section](#native-setup-not-recommended-for-beginners).
+There are two ways to get Peregrine runnning for development. You can either run it in docker (recommended for beginners), or you can run it natively on your machine. If you are having issues with Docker, you may want to try running the app natively. If you chose the docker route, stay in this section. Otherwise, go to the [native setup section](#native-setup-not-recommended-for-beginners).
 
 1. [Install Docker](https://docs.docker.com/install/) and start the daemon. Also, install [docker-compose](https://docs.docker.com/compose/install/).
 

--- a/SCOUTING.md
+++ b/SCOUTING.md
@@ -1,0 +1,13 @@
+# Scouting
+
+## What's Scouting?
+
+Scouting is when teams observe the behaviors of a team’s robot throughout matches they compete in within an event. When scouting other teams, scouts look for how a robot performs certain actions during a match, the overall functionality of the team's robot, and how efficient the performance of drive teams are.
+
+## Why Do We Scout?
+
+The most basic reason we scout is that data we receive from scouting assists us in alliance selections, where highly ranked teams select other teams to join their alliance and compete in playoff matches in hopes to exit the event as the finalist winner. The alliance captains, those who choose other robots to join their alliance, rely on scouting data to strategize which teams will complement their robot's abilities in a game. Cooperating well as a team is critical to playoff matches, as not doing so can cost an alliance many points in a match. Before a match, it's helpful for Drive Captains to know which teams they are competing against as well as who is on their alliance. Scouting gives Drive Captains that insight, and they use the data to strategize with other teams on their alliance to win the upcoming match.
+
+## Why Use a Scouting App?
+
+A scouting app solves many problems found in traditional paper scouting methods. Most FRC teams use a certain, inefficient process to scout matches; while matches are playing, scouts write data onto paper by checking boxes or filling in numbers based on how a robot competed during the match. Afterward, the data is manually entered into a spreadsheet, tending to be disorganized and difficult to interpret. Because manually entering data into a spreadsheet takes up extra time, the process of strategizing for alliance selections is delayed. In addition, a disorderly spreadsheet makes tracking a team's progress throughout an event challenging. Through a scouting app, the process of manually entering data after matches is eliminated, which allows for the pre-alliance selection process to begin much earlier. The data is immediately uploaded to an organized, easy-to-follow spreadsheet, and multiple graphs are created that display a robot's progress during an event. These components allow for Drive Captains to analyze their opponents quickly.

--- a/api-tests/api.test.js
+++ b/api-tests/api.test.js
@@ -15,11 +15,16 @@ const address = `http://${config.server.httpAddress}`
 
 const youtubeOrTwitch = /^(youtube|twitch)$/
 
+const seedUser = {
+  username: 'test',
+  password: 'testpassword',
+}
+
 module.exports = {
   address,
   config,
   youtubeOrTwitch,
-  getJWT: async (user = config.seedUser) => {
+  getJWT: async (user = seedUser) => {
     const resp = await fetch(address + '/authenticate', {
       method: 'POST',
       body: JSON.stringify({

--- a/api-tests/api.test.js
+++ b/api-tests/api.test.js
@@ -18,12 +18,17 @@ const youtubeOrTwitch = /^(youtube|twitch)$/
 const seedUser = {
   username: 'test',
   password: 'testpassword',
+  roles: {
+    isAdmin: true,
+    isVerified: true,
+  },
 }
 
 module.exports = {
   address,
   config,
   youtubeOrTwitch,
+  seedUser,
   getJWT: async (user = seedUser) => {
     const resp = await fetch(address + '/authenticate', {
       method: 'POST',

--- a/api-tests/route-tests/events.test.js
+++ b/api-tests/route-tests/events.test.js
@@ -34,7 +34,7 @@ test('/events endpoint', async () => {
 })
 
 test('/events create endpoint', async () => {
-  expect(api.config.seedUser.roles.isAdmin).toBe(true)
+  expect(api.seedUser.roles.isAdmin).toBe(true)
 
   const event = {
     key: '1970flir',

--- a/api-tests/route-tests/matches.test.js
+++ b/api-tests/route-tests/matches.test.js
@@ -69,7 +69,7 @@ test('/events/{eventKey}/matches endpoint with filter for multiple teams on oppo
 })
 
 test('/matches create endpoint', async () => {
-  expect(api.config.seedUser.roles.isAdmin).toBe(true)
+  expect(api.seedUser.roles.isAdmin).toBe(true)
 
   const event = {
     key: '1970flir',

--- a/api-tests/route-tests/users.test.js
+++ b/api-tests/route-tests/users.test.js
@@ -6,8 +6,8 @@ describe('auth endpoints', () => {
     const resp = await fetch(api.address + '/authenticate', {
       method: 'POST',
       body: JSON.stringify({
-        username: api.config.seedUser.username,
-        password: api.config.seedUser.password,
+        username: api.seedUser.username,
+        password: api.seedUser.password,
       }),
       headers: { 'Content-Type': 'application/json' },
     })
@@ -22,8 +22,8 @@ describe('auth endpoints', () => {
     const resp = await fetch(api.address + '/authenticate', {
       method: 'POST',
       body: JSON.stringify({
-        username: api.config.seedUser.username,
-        password: api.config.seedUser.password + 'a',
+        username: api.seedUser.username,
+        password: api.seedUser.password + 'a',
       }),
       headers: { 'Content-Type': 'application/json' },
     })

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -21,16 +21,17 @@ func main() {
 	var down = flag.Bool("down", false, "Migrate down. Cannot be used with -up.")
 	var migrationsTable = flag.String("migrationsTable", "migrations", "Name of SQL table to store migrations in.")
 	var basePath = flag.String("basePath", ".", "Path to the etc directory where the config file is.")
+	var migrationsPath = flag.String("migrationsPath", "migrations", "Path to migrations from etc directory.")
 
 	flag.Parse()
 
-	if err := run(*steps, *up, *down, *migrationsTable, *basePath); err != nil {
+	if err := run(*steps, *up, *down, *migrationsTable, *basePath, *migrationsPath); err != nil {
 		fmt.Printf("got error: %v\n", err)
 		os.Exit(1)
 	}
 }
 
-func run(steps int, up, down bool, migrationsTable, basePath string) error {
+func run(steps int, up, down bool, migrationsTable, basePath, migrationsPath string) error {
 	// Neither are set or both are set
 	if up == down {
 		return fmt.Errorf("must specify either -up or -down")
@@ -59,7 +60,7 @@ func run(steps int, up, down bool, migrationsTable, basePath string) error {
 	} else {
 		migrationsSource += "./"
 	}
-	migrationsSource += "migrations"
+	migrationsSource += migrationsPath
 
 	m, err := migrate.NewWithDatabaseInstance(
 		migrationsSource,

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -42,13 +42,13 @@ func run(steps int, up, down bool, migrationsTable, basePath, migrationsPath str
 		return errors.Wrap(err, "opening config")
 	}
 
-	db, err := sql.Open("postgres", c.Database.ConnectionInfo())
+	db, err := sql.Open("postgres", c.DSN)
 	if err != nil {
 		return errors.Wrap(err, "connecting to database")
 	}
 	defer db.Close()
 
-	config := &postgres.Config{MigrationsTable: migrationsTable, DatabaseName: c.Database.Name}
+	config := &postgres.Config{MigrationsTable: migrationsTable}
 	driver, err := postgres.WithInstance(db, config)
 	if err != nil {
 		return errors.Wrap(err, "getting postgresql driver")
@@ -64,7 +64,7 @@ func run(steps int, up, down bool, migrationsTable, basePath, migrationsPath str
 
 	m, err := migrate.NewWithDatabaseInstance(
 		migrationsSource,
-		c.Database.Name, driver)
+		"peregrine", driver)
 	if err != nil {
 		return errors.Wrap(err, "opening migrations")
 	}

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -20,7 +20,7 @@ func main() {
 	var up = flag.Bool("up", false, "Migrate up. Cannot be used with -down.")
 	var down = flag.Bool("down", false, "Migrate down. Cannot be used with -up.")
 	var migrationsTable = flag.String("migrationsTable", "migrations", "Name of SQL table to store migrations in.")
-	var basePath = flag.String("basePath", "", "Path to the etc directory where the config file is.")
+	var basePath = flag.String("basePath", ".", "Path to the etc directory where the config file is.")
 
 	flag.Parse()
 

--- a/cmd/peregrine/main.go
+++ b/cmd/peregrine/main.go
@@ -37,7 +37,7 @@ func run(basePath string) error {
 		APIKey: c.TBA.APIKey,
 	}
 
-	sto, err := store.New(c.Database)
+	sto, err := store.New(c.DSN)
 	if err != nil {
 		return errors.Wrap(err, "opening postgres server")
 	}

--- a/cmd/peregrine/main.go
+++ b/cmd/peregrine/main.go
@@ -13,7 +13,6 @@ import (
 	"github.com/Pigmice2733/peregrine-backend/internal/tba"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/crypto/bcrypt"
 )
 
 func main() {
@@ -41,26 +40,6 @@ func run(basePath string) error {
 	sto, err := store.New(c.Database)
 	if err != nil {
 		return errors.Wrap(err, "opening postgres server")
-	}
-
-	if c.SeedUser != nil {
-		hashedPassword, err := bcrypt.GenerateFromPassword([]byte(c.SeedUser.Password), bcrypt.DefaultCost)
-		if err != nil {
-			return errors.Wrap(err, "creating seed user hashed password")
-		}
-
-		u := store.User{
-			Username:       c.SeedUser.Username,
-			HashedPassword: string(hashedPassword),
-			FirstName:      c.SeedUser.FirstName,
-			LastName:       c.SeedUser.LastName,
-			Roles:          c.SeedUser.Roles,
-		}
-
-		err = sto.CreateUser(u)
-		if err != nil && err != store.ErrExists {
-			return errors.Wrap(err, "creating seed user")
-		}
 	}
 
 	if c.Server.Year == 0 {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       POSTGRES_USER: peregrine
       POSTGRES_PASSWORD: ""
     ports:
-      - 5432:5432
+      - "5432:5432"
 
   migrate:
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
 
   app:
     environment:
+      - CGO_ENABLED=0
       - GO_ENV=docker
       - TBA_API_KEY=${TBA_API_KEY}
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,25 @@ services:
     links:
       - db
 
+  seed:
+    environment:
+      - GO_ENV=docker
+    build: .
+    command:
+      [
+        "migrate",
+        "-up",
+        "-migrationsTable",
+        "seedmigrations",
+        "-migrationsPath",
+        "seed-migrations",
+      ]
+    depends_on:
+      - db
+      - migrate
+    links:
+      - db
+
   app:
     environment:
       - GO_ENV=docker
@@ -30,6 +49,6 @@ services:
     depends_on:
       - db
       - migrate
+      # - seed
     links:
       - db
-      - migrate

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,8 @@ services:
     environment:
       - GO_ENV=docker
     build: .
-    command: ["migrate", "-up"]
+    command:
+      ["./wait-for-it.sh", "-h", "db", "-p", "5432", "--", "migrate", "-up"]
     depends_on:
       - db
     links:
@@ -25,6 +26,12 @@ services:
     build: .
     command:
       [
+        "./wait-for-it.sh",
+        "-h",
+        "db",
+        "-p",
+        "5432",
+        "--",
         "migrate",
         "-up",
         "-migrationsTable",
@@ -43,12 +50,12 @@ services:
       - GO_ENV=docker
       - TBA_API_KEY=${TBA_API_KEY}
     build: .
-    command: ["peregrine"]
+    command: ["./wait-for-it.sh", "-h", "db", "-p", "5432", "--", "peregrine"]
     ports:
       - "8080:8080"
     depends_on:
       - db
       - migrate
-      # - seed
+      - seed
     links:
       - db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
   app:
     environment:
       - GO_ENV=docker
-      - TBA_API_KEY=${TBA_API_KEY}
+      - PRGN_TBA_API_KEY=${PRGN_TBA_API_KEY}
     build: .
     command: ["./wait-for-it.sh", "-h", "db", "-p", "5432", "--", "peregrine"]
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,8 +26,8 @@ services:
       - GO_ENV=docker
       - TBA_API_KEY=${TBA_API_KEY}
     build: .
-    working_dir: /go/src/github.com/Pigmice2733/peregrine-backend/cmd/peregrine
-    command: ["watcher", "-basePath", "../.."]
+    working_dir: /go/src/github.com/Pigmice2733/peregrine-backend
+    command: ["./watch.sh", "peregrine"]
     volumes:
       - .:/go/src/github.com/Pigmice2733/peregrine-backend
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
   app:
     environment:
       - CGO_ENABLED=0
+      - GOOS=linux
       - GO_ENV=docker
       - TBA_API_KEY=${TBA_API_KEY}
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+version: "3"
+services:
+  db:
+    image: postgres
+    environment:
+      POSTGRES_DB: peregrine
+      POSTGRES_USER: peregrine
+      POSTGRES_PASSWORD: ""
+    ports:
+      - 5432:5432
+
+  migrate:
+    environment:
+      - GO_ENV=docker
+    build: .
+    command: ["migrate", "-up"]
+    volumes:
+      - .:/go/src/github.com/Pigmice2733/peregrine-backend
+    depends_on:
+      - db
+    links:
+      - db
+
+  app:
+    environment:
+      - GO_ENV=docker
+      - TBA_API_KEY=${TBA_API_KEY}
+    build: .
+    working_dir: /go/src/github.com/Pigmice2733/peregrine-backend/cmd/peregrine
+    command: ["watcher", "-basePath", "../.."]
+    volumes:
+      - .:/go/src/github.com/Pigmice2733/peregrine-backend
+    ports:
+      - "8080:8080"
+    depends_on:
+      - db
+      - migrate
+    links:
+      - db
+      - migrate

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,6 @@ services:
       - GO_ENV=docker
     build: .
     command: ["migrate", "-up"]
-    volumes:
-      - .:/go/src/github.com/Pigmice2733/peregrine-backend
     depends_on:
       - db
     links:
@@ -23,15 +21,10 @@ services:
 
   app:
     environment:
-      - CGO_ENABLED=0
-      - GOOS=linux
       - GO_ENV=docker
       - TBA_API_KEY=${TBA_API_KEY}
     build: .
-    working_dir: /go/src/github.com/Pigmice2733/peregrine-backend
-    command: ["./watch.sh", "peregrine"]
-    volumes:
-      - .:/go/src/github.com/Pigmice2733/peregrine-backend
+    command: ["peregrine"]
     ports:
       - "8080:8080"
     depends_on:

--- a/etc/config.docker.yaml
+++ b/etc/config.docker.yaml
@@ -1,0 +1,14 @@
+server:
+  httpAddress: :8080
+  origin: "*"
+  logJSON: false
+
+tba:
+  URL: https://www.thebluealliance.com/api/v3
+
+database:
+  user: peregrine
+  host: db
+  port: 5432
+  name: peregrine
+  sslMode: disable

--- a/etc/config.docker.yaml
+++ b/etc/config.docker.yaml
@@ -12,12 +12,3 @@ database:
   port: 5432
   name: peregrine
   sslMode: disable
-
-seedUser:
-  username: test
-  password: testpassword
-  firstName: John
-  lastName: Doe
-  roles:
-    isVerified: true
-    isAdmin: true

--- a/etc/config.docker.yaml
+++ b/etc/config.docker.yaml
@@ -1,5 +1,5 @@
 server:
-  httpAddress: :8080
+  httpAddress: 0.0.0.0:8080
   origin: "*"
   logJSON: false
 
@@ -12,3 +12,12 @@ database:
   port: 5432
   name: peregrine
   sslMode: disable
+
+seedUser:
+  username: test
+  password: testpassword
+  firstName: John
+  lastName: Doe
+  roles:
+    isVerified: true
+    isAdmin: true

--- a/etc/config.docker.yaml
+++ b/etc/config.docker.yaml
@@ -1,14 +1,4 @@
 server:
   httpAddress: 0.0.0.0:8080
-  origin: "*"
-  logJSON: false
 
-tba:
-  URL: https://www.thebluealliance.com/api/v3
-
-database:
-  user: peregrine
-  host: db
-  port: 5432
-  name: peregrine
-  sslMode: disable
+dsn: user=peregrine host=db port=5432 dbname=peregrine sslmode=disable

--- a/etc/config.testing.yaml
+++ b/etc/config.testing.yaml
@@ -1,16 +1,5 @@
 server:
-  httpAddress: localhost:8080
-  origin: "*"
+  httpAddress: 0.0.0.0:8080
   year: 2018
-  logJSON: false
 
-tba:
-  URL: https://www.thebluealliance.com/api/v3
-
-database:
-  user: peregrine
-  password: ""
-  host: localhost
-  port: 5432
-  name: peregrine
-  sslMode: disable
+dsn: user=postgres port=5432 dbname=peregrine sslmode=disable

--- a/etc/config.testing.yaml
+++ b/etc/config.testing.yaml
@@ -2,4 +2,4 @@ server:
   httpAddress: 0.0.0.0:8080
   year: 2018
 
-dsn: user=postgres port=5432 dbname=peregrine sslmode=disable
+dsn: user=peregrine port=5432 dbname=peregrine sslmode=disable

--- a/etc/config.testing.yaml
+++ b/etc/config.testing.yaml
@@ -14,12 +14,3 @@ database:
   port: 5432
   name: peregrine
   sslMode: disable
-
-seedUser:
-  username: test
-  password: testpassword
-  firstName: John
-  lastName: Doe
-  roles:
-    isVerified: true
-    isAdmin: true

--- a/etc/config.yaml.template
+++ b/etc/config.yaml.template
@@ -14,12 +14,3 @@ database:
     port: 5432
     name: peregrine
     sslMode: disable
-
-seedUser:
-  username: test
-  password: testpassword
-  firstName: John
-  lastName: Doe
-  roles:
-    isVerified: true
-    isAdmin: true

--- a/etc/config.yaml.template
+++ b/etc/config.yaml.template
@@ -1,5 +1,5 @@
 server:
-    httpAddress: :8080
+    httpAddress: localhost:8080
     origin: "*"
     logJSON: false
 
@@ -14,3 +14,12 @@ database:
     port: 5432
     name: peregrine
     sslMode: disable
+
+seedUser:
+  username: test
+  password: testpassword
+  firstName: John
+  lastName: Doe
+  roles:
+    isVerified: true
+    isAdmin: true

--- a/etc/config.yaml.template
+++ b/etc/config.yaml.template
@@ -1,16 +1,7 @@
 server:
-    httpAddress: localhost:8080
-    origin: "*"
-    logJSON: false
+  httpAddress: 0.0.0.0:8080
 
 tba:
-    URL: https://www.thebluealliance.com/api/v3
-    apiKey: tbaAPIKey
+    apiKey: "your-api-key-here"
 
-database:
-    user: postgres
-    password: ""
-    host: localhost
-    port: 5432
-    name: peregrine
-    sslMode: disable
+dsn: user=postgres port=5432 dbname=peregrine sslmode=disable

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,7 +49,9 @@ func Open(basePath string) (Config, error) {
 		"logJSON":     false,
 	})
 	viper.SetDefault("tba.url", "https://www.thebluealliance.com/api/v3")
-	viper.BindEnv("tba.apiKey", "PRGN_TBA_API_KEY")
+	if err := viper.BindEnv("tba.apiKey", "PRGN_TBA_API_KEY"); err != nil {
+		return Config{}, errors.Wrap(err, "unable to bind viper env var for api key")
+	}
 
 	if err := viper.ReadInConfig(); err != nil {
 		return Config{}, errors.Wrap(err, "unable to read in config file")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,12 +1,12 @@
 package config
 
 import (
-	"fmt"
 	"os"
 	"path"
+	"time"
 
-	"github.com/Pigmice2733/peregrine-backend/internal/store"
-	yaml "gopkg.in/yaml.v2"
+	"github.com/pkg/errors"
+	"github.com/spf13/viper"
 )
 
 // Server holds information about the peregrine backend HTTP server.
@@ -29,7 +29,7 @@ type Config struct {
 		APIKey string `yaml:"apiKey"`
 	} `yaml:"tba"`
 
-	Database store.Options `yaml:"database"`
+	DSN string `yaml:"dsn"`
 }
 
 // Open opens basePath/etc/config.$GO_ENV.json as a Config
@@ -39,19 +39,25 @@ func Open(basePath string) (Config, error) {
 		environment = goEnv
 	}
 
-	f, err := os.Open(path.Join(basePath, "etc", fmt.Sprintf("config.%s.yaml", environment)))
-	if err != nil {
-		return Config{}, err
+	viper.AddConfigPath(path.Join(basePath, "etc"))
+	viper.SetConfigName("config." + environment)
+
+	viper.SetDefault("server", map[string]interface{}{
+		"httpAddress": ":8080",
+		"origin":      "*",
+		"year":        time.Now().Year(),
+		"logJSON":     false,
+	})
+	viper.SetDefault("tba.url", "https://www.thebluealliance.com/api/v3")
+	viper.BindEnv("tba.apiKey", "PRGN_TBA_API_KEY")
+
+	if err := viper.ReadInConfig(); err != nil {
+		return Config{}, errors.Wrap(err, "unable to read in config file")
 	}
-	defer f.Close()
 
 	var c Config
-	if err := yaml.NewDecoder(f).Decode(&c); err != nil {
-		return c, err
-	}
-
-	if apiKey, ok := os.LookupEnv("TBA_API_KEY"); ok {
-		c.TBA.APIKey = apiKey
+	if err := viper.Unmarshal(&c); err != nil {
+		return c, errors.Wrap(err, "unable to unmarshal config from viper")
 	}
 
 	return c, nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,14 +29,6 @@ type Config struct {
 		APIKey string `yaml:"apiKey"`
 	} `yaml:"tba"`
 
-	SeedUser *struct {
-		Username  string      `yaml:"username"`
-		Password  string      `yaml:"password"`
-		FirstName string      `yaml:"firstName"`
-		LastName  string      `yaml:"lastName"`
-		Roles     store.Roles `yaml:"roles"`
-	} `yaml:"seedUser"`
-
 	Database store.Options `yaml:"database"`
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -18,24 +18,9 @@ type Service struct {
 	db *sqlx.DB
 }
 
-// Options holds information for connecting to a PostgreSQL instance.
-type Options struct {
-	User    string `yaml:"user"`
-	Pass    string `yaml:"pass"`
-	Host    string `yaml:"host"`
-	Port    int    `yaml:"port"`
-	Name    string `yaml:"name"`
-	SSLMode string `yaml:"sslMode"`
-}
-
-// ConnectionInfo returns the PostgreSQL connection string from an options struct.
-func (o Options) ConnectionInfo() string {
-	return fmt.Sprintf("host='%s' port='%d' user='%s' password='%s' dbname='%s' sslmode='%s'", o.Host, o.Port, o.User, o.Pass, o.Name, o.SSLMode)
-}
-
-// New creates a new store service.
-func New(o Options) (Service, error) {
-	db, err := sqlx.Open("postgres", o.ConnectionInfo())
+// New creates a new store service from a dataSourceName.
+func New(dsn string) (Service, error) {
+	db, err := sqlx.Open("postgres", dsn)
 	if err != nil {
 		return Service{}, err
 	}

--- a/seed-migrations/1_seed_user.down.sql
+++ b/seed-migrations/1_seed_user.down.sql
@@ -1,0 +1,1 @@
+DELETE FROM users WHERE username = 'test';

--- a/seed-migrations/1_seed_user.up.sql
+++ b/seed-migrations/1_seed_user.up.sql
@@ -1,0 +1,14 @@
+INSERT INTO users (
+        username,
+        hashed_password,
+        first_name,
+        last_name,
+        roles
+    )
+    VALUES (
+        'test',
+        '$2a$04$oLK1h.TmOdsz6PUszjzj3eEjCXdoz8RIh5Q8lIb5aTmVtLCNK.DTG',
+        'John',
+        'Doe',
+        '{"isVerified": true, "isAdmin": true}'
+    )

--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+#   Use this script to test if a given TCP host/port are available
+
+WAITFORIT_cmdname=${0##*/}
+
+echoerr() { if [[ $WAITFORIT_QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $WAITFORIT_cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+wait_for()
+{
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    else
+        echoerr "$WAITFORIT_cmdname: waiting for $WAITFORIT_HOST:$WAITFORIT_PORT without a timeout"
+    fi
+    WAITFORIT_start_ts=$(date +%s)
+    while :
+    do
+        if [[ $WAITFORIT_ISBUSY -eq 1 ]]; then
+            nc -z $WAITFORIT_HOST $WAITFORIT_PORT
+            WAITFORIT_result=$?
+        else
+            (echo > /dev/tcp/$WAITFORIT_HOST/$WAITFORIT_PORT) >/dev/null 2>&1
+            WAITFORIT_result=$?
+        fi
+        if [[ $WAITFORIT_result -eq 0 ]]; then
+            WAITFORIT_end_ts=$(date +%s)
+            echoerr "$WAITFORIT_cmdname: $WAITFORIT_HOST:$WAITFORIT_PORT is available after $((WAITFORIT_end_ts - WAITFORIT_start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $WAITFORIT_result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $WAITFORIT_QUIET -eq 1 ]]; then
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --quiet --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    else
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    fi
+    WAITFORIT_PID=$!
+    trap "kill -INT -$WAITFORIT_PID" INT
+    wait $WAITFORIT_PID
+    WAITFORIT_RESULT=$?
+    if [[ $WAITFORIT_RESULT -ne 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: timeout occurred after waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    fi
+    return $WAITFORIT_RESULT
+}
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        WAITFORIT_hostport=(${1//:/ })
+        WAITFORIT_HOST=${WAITFORIT_hostport[0]}
+        WAITFORIT_PORT=${WAITFORIT_hostport[1]}
+        shift 1
+        ;;
+        --child)
+        WAITFORIT_CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        WAITFORIT_QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        WAITFORIT_STRICT=1
+        shift 1
+        ;;
+        -h)
+        WAITFORIT_HOST="$2"
+        if [[ $WAITFORIT_HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        WAITFORIT_HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        WAITFORIT_PORT="$2"
+        if [[ $WAITFORIT_PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        WAITFORIT_PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        WAITFORIT_TIMEOUT="$2"
+        if [[ $WAITFORIT_TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        WAITFORIT_TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        WAITFORIT_CLI=("$@")
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$WAITFORIT_HOST" == "" || "$WAITFORIT_PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+
+WAITFORIT_TIMEOUT=${WAITFORIT_TIMEOUT:-15}
+WAITFORIT_STRICT=${WAITFORIT_STRICT:-0}
+WAITFORIT_CHILD=${WAITFORIT_CHILD:-0}
+WAITFORIT_QUIET=${WAITFORIT_QUIET:-0}
+
+# check to see if timeout is from busybox?
+WAITFORIT_TIMEOUT_PATH=$(type -p timeout)
+WAITFORIT_TIMEOUT_PATH=$(realpath $WAITFORIT_TIMEOUT_PATH 2>/dev/null || readlink -f $WAITFORIT_TIMEOUT_PATH)
+if [[ $WAITFORIT_TIMEOUT_PATH =~ "busybox" ]]; then
+        WAITFORIT_ISBUSY=1
+        WAITFORIT_BUSYTIMEFLAG="-t"
+
+else
+        WAITFORIT_ISBUSY=0
+        WAITFORIT_BUSYTIMEFLAG=""
+fi
+
+if [[ $WAITFORIT_CHILD -gt 0 ]]; then
+    wait_for
+    WAITFORIT_RESULT=$?
+    exit $WAITFORIT_RESULT
+else
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        WAITFORIT_RESULT=$?
+    else
+        wait_for
+        WAITFORIT_RESULT=$?
+    fi
+fi
+
+if [[ $WAITFORIT_CLI != "" ]]; then
+    if [[ $WAITFORIT_RESULT -ne 0 && $WAITFORIT_STRICT -eq 1 ]]; then
+        echoerr "$WAITFORIT_cmdname: strict mode, refusing to execute subprocess"
+        exit $WAITFORIT_RESULT
+    fi
+    exec "${WAITFORIT_CLI[@]}"
+else
+    exit $WAITFORIT_RESULT
+fi

--- a/watch.sh
+++ b/watch.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-while true; do
-  go install ./...
-  $@ &
-  PID=$!
-  inotifywait --exclude "[^g][^o]$" -r -e modify .
-  kill $PID
-done

--- a/watch.sh
+++ b/watch.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+
 while true; do
   go install ./...
   $@ &

--- a/watch.sh
+++ b/watch.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+while true; do
+  go install ./...
+  $@ &
+  PID=$!
+  inotifywait --exclude "[^g][^o]$" -r -e modify .
+  kill $PID
+done


### PR DESCRIPTION
# Goal
Adds docker to make it easier for new developers to get started. Also adds documentation to README.md for using docker. Closes #122 

# Testing
Follow the instructions in the README.md and see if you can use docker to run the app. Check if live-reload works as documented.

# Notes
I tagged @NathanJesudason and @j10k11 for review. Please attempt to setup the scouting app via the instructions added to the README.md. View the updated README.md [here](https://github.com/Pigmice2733/peregrine-backend/blob/docker-development/README.md). Leave feedback on what you had trouble with. Make sure that when you clone the repo you checkout this branch with `git checkout docker-development`.