### PR TITLE
Error housekeeping: wrap errors more/better, use errors.New, etc

### DIFF
--- a/api-tests/route-tests/users.test.js
+++ b/api-tests/route-tests/users.test.js
@@ -40,7 +40,7 @@ test('users CRUD', async () => {
   let otherRealmId
 
   let otherRealm = {
-    name: 'TMM',
+    name: 'TMM' + Number(new Date()),
     shareReports: false,
   }
 

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -34,7 +34,7 @@ func main() {
 func run(steps int, up, down bool, migrationsTable, basePath, migrationsPath string) error {
 	// Neither are set or both are set
 	if up == down {
-		return fmt.Errorf("must specify either -up or -down")
+		return errors.New("must specify either -up or -down")
 	}
 
 	c, err := config.Open(basePath)

--- a/etc/config.docker.yaml
+++ b/etc/config.docker.yaml
@@ -1,4 +1,5 @@
 server:
   httpAddress: 0.0.0.0:8080
+  year: 2018
 
 dsn: user=peregrine host=db port=5432 dbname=peregrine sslmode=disable

--- a/internal/http/context.go
+++ b/internal/http/context.go
@@ -1,7 +1,7 @@
 package http
 
 import (
-	"fmt"
+	"errors"
 	"net/http"
 	"strconv"
 
@@ -28,17 +28,17 @@ type Claims struct {
 func GetSubject(r *http.Request) (int64, error) {
 	contextSubject := r.Context().Value(keySubjectContext)
 	if contextSubject == nil {
-		return 0, fmt.Errorf("no subject set on context")
+		return 0, errors.New("no subject set on context")
 	}
 
 	sub, ok := contextSubject.(string)
 	if !ok {
-		return 0, fmt.Errorf("got invalid type for subject")
+		return 0, errors.New("got invalid type for subject")
 	}
 
 	id, err := strconv.ParseInt(sub, 10, 64)
 	if err != nil {
-		return 0, fmt.Errorf("unable to parse subject as int")
+		return 0, errors.New("unable to parse subject as int")
 	}
 
 	return id, nil
@@ -63,12 +63,12 @@ func GetRoles(r *http.Request) store.Roles {
 func GetRealmID(r *http.Request) (int64, error) {
 	contextRealm := r.Context().Value(keyRealmContext)
 	if contextRealm == nil {
-		return 0, fmt.Errorf("no realm set on context")
+		return 0, errors.New("no realm set on context")
 	}
 
 	realmID, ok := contextRealm.(int64)
 	if !ok {
-		return 0, fmt.Errorf("got invalid type for realm")
+		return 0, errors.New("got invalid type for realm")
 	}
 	return realmID, nil
 }

--- a/internal/server/matches.go
+++ b/internal/server/matches.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Pigmice2733/peregrine-backend/internal/store"
 	"github.com/Pigmice2733/peregrine-backend/internal/tba"
 	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
 )
 
 type match struct {
@@ -44,7 +45,7 @@ func (s *Server) matchesHandler() http.HandlerFunc {
 		// Get new match data from TBA
 		if err := s.updateMatches(eventKey); err != nil {
 			// 404 if eventKey isn't a real event
-			if _, ok := err.(*store.ErrNoResults); ok {
+			if _, ok := errors.Cause(err).(store.ErrNoResults); ok {
 				ihttp.Error(w, http.StatusNotFound)
 				return
 			}
@@ -105,7 +106,7 @@ func (s *Server) matchHandler() http.HandlerFunc {
 		// Get new match data from TBA
 		if err := s.updateMatches(eventKey); err != nil {
 			// 404 if eventKey isn't a real event
-			if _, ok := err.(*store.ErrNoResults); ok {
+			if _, ok := errors.Cause(err).(store.ErrNoResults); ok {
 				ihttp.Error(w, http.StatusNotFound)
 				return
 			}
@@ -116,7 +117,7 @@ func (s *Server) matchHandler() http.HandlerFunc {
 
 		fullMatch, err := s.Store.GetMatch(matchKey)
 		if err != nil {
-			if _, ok := err.(*store.ErrNoResults); ok {
+			if _, ok := errors.Cause(err).(store.ErrNoResults); ok {
 				ihttp.Error(w, http.StatusNotFound)
 				return
 			}
@@ -200,7 +201,7 @@ func (s *Server) updateMatches(eventKey string) error {
 	}
 
 	fullMatches, err := s.TBA.GetMatches(eventKey)
-	if _, ok := err.(tba.ErrNotModified); ok {
+	if _, ok := errors.Cause(err).(tba.ErrNotModified); ok {
 		return nil
 	} else if err != nil {
 		return err

--- a/internal/server/realms.go
+++ b/internal/server/realms.go
@@ -9,6 +9,7 @@ import (
 	ihttp "github.com/Pigmice2733/peregrine-backend/internal/http"
 	"github.com/Pigmice2733/peregrine-backend/internal/store"
 	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
 	validator "gopkg.in/go-playground/validator.v9"
 )
 
@@ -39,7 +40,7 @@ func (s *Server) createRealmHandler() http.HandlerFunc {
 		realm := store.Realm{Name: rr.Name, ShareReports: rr.ShareReports}
 
 		id, err := s.Store.InsertRealm(realm)
-		if _, ok := err.(*store.ErrExists); ok {
+		if _, ok := errors.Cause(err).(store.ErrExists); ok {
 			ihttp.Error(w, http.StatusConflict)
 			return
 		} else if err != nil {
@@ -106,7 +107,7 @@ func (s *Server) realmHandler() http.HandlerFunc {
 		}
 
 		realm, err := s.Store.GetRealm(id)
-		if _, ok := err.(*store.ErrNoResults); ok {
+		if _, ok := errors.Cause(err).(store.ErrNoResults); ok {
 			ihttp.Error(w, http.StatusNotFound)
 			return
 		} else if err != nil {
@@ -178,7 +179,7 @@ func (s *Server) patchRealmHandler() http.HandlerFunc {
 		sr := store.PatchRealm{ID: id, Name: pr.Name, ShareReports: pr.ShareReports}
 
 		err = s.Store.PatchRealm(sr)
-		if _, ok := err.(*store.ErrNoResults); ok {
+		if _, ok := errors.Cause(err).(store.ErrNoResults); ok {
 			ihttp.Error(w, http.StatusNotFound)
 			return
 		} else if err != nil {

--- a/internal/server/teams.go
+++ b/internal/server/teams.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Pigmice2733/peregrine-backend/internal/store"
 	"github.com/Pigmice2733/peregrine-backend/internal/tba"
 	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
 )
 
 type team struct {
@@ -34,7 +35,7 @@ func (s *Server) teamsHandler() http.HandlerFunc {
 		// Get new team data from TBA
 		if err := s.updateTeamKeys(eventKey); err != nil {
 			// 404 if eventKey isn't a real event
-			if _, ok := err.(*store.ErrNoResults); ok {
+			if _, ok := errors.Cause(err).(store.ErrNoResults); ok {
 				ihttp.Error(w, http.StatusNotFound)
 				return
 			}
@@ -75,7 +76,7 @@ func (s *Server) teamInfoHandler() http.HandlerFunc {
 		// Get new team rankings data from TBA
 		if err := s.updateTeamRankings(eventKey); err != nil {
 			// 404 if eventKey isn't a real event
-			if _, ok := err.(*store.ErrNoResults); ok {
+			if _, ok := errors.Cause(err).(store.ErrNoResults); ok {
 				ihttp.Error(w, http.StatusNotFound)
 				return
 			}
@@ -86,7 +87,7 @@ func (s *Server) teamInfoHandler() http.HandlerFunc {
 
 		fullTeam, err := s.Store.GetTeam(teamKey, eventKey)
 		if err != nil {
-			if _, ok := err.(*store.ErrNoResults); ok {
+			if _, ok := errors.Cause(err).(store.ErrNoResults); ok {
 				ihttp.Error(w, http.StatusNotFound)
 				return
 			}
@@ -116,7 +117,7 @@ func (s *Server) updateTeamKeys(eventKey string) error {
 	}
 
 	teams, err := s.TBA.GetTeamKeys(eventKey)
-	if _, ok := err.(tba.ErrNotModified); ok {
+	if _, ok := errors.Cause(err).(tba.ErrNotModified); ok {
 		return nil
 	} else if err != nil {
 		return err
@@ -137,7 +138,7 @@ func (s *Server) updateTeamRankings(eventKey string) error {
 	}
 
 	teams, err := s.TBA.GetTeamRankings(eventKey)
-	if _, ok := err.(tba.ErrNotModified); ok {
+	if _, ok := errors.Cause(err).(tba.ErrNotModified); ok {
 		return nil
 	} else if err != nil {
 		return err

--- a/internal/server/users.go
+++ b/internal/server/users.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Pigmice2733/peregrine-backend/internal/store"
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
 	"golang.org/x/crypto/bcrypt"
 	validator "gopkg.in/go-playground/validator.v9"
 )
@@ -43,7 +44,7 @@ func (s *Server) authenticateHandler() http.HandlerFunc {
 		}
 
 		user, err := s.Store.GetUserByUsername(ru.Username)
-		if _, ok := err.(*store.ErrNoResults); ok {
+		if _, ok := errors.Cause(err).(store.ErrNoResults); ok {
 			ihttp.Error(w, http.StatusUnauthorized)
 			return
 		} else if err != nil {
@@ -124,10 +125,10 @@ func (s *Server) createUserHandler() http.HandlerFunc {
 		u.HashedPassword = string(hashedPassword)
 
 		err = s.Store.CreateUser(u)
-		if _, ok := err.(*store.ErrExists); ok {
+		if _, ok := errors.Cause(err).(store.ErrExists); ok {
 			ihttp.Respond(w, err, http.StatusConflict)
 			return
-		} else if _, ok := err.(*store.ErrFKeyViolation); ok {
+		} else if _, ok := errors.Cause(err).(store.ErrFKeyViolation); ok {
 			ihttp.Respond(w, err, http.StatusUnprocessableEntity)
 			return
 		} else if err != nil {
@@ -192,7 +193,7 @@ func (s *Server) getUserByIDHandler() http.HandlerFunc {
 		}
 
 		user, err := s.Store.GetUserByID(id)
-		if _, ok := err.(*store.ErrNoResults); ok {
+		if _, ok := errors.Cause(err).(store.ErrNoResults); ok {
 			ihttp.Error(w, http.StatusNotFound)
 			return
 		} else if err != nil {
@@ -291,10 +292,10 @@ func (s *Server) patchUserHandler() http.HandlerFunc {
 		}
 
 		err = s.Store.PatchUser(u)
-		if _, ok := err.(*store.ErrNoResults); ok {
+		if _, ok := errors.Cause(err).(store.ErrNoResults); ok {
 			ihttp.Error(w, http.StatusNotFound)
 			return
-		} else if _, ok := err.(*store.ErrFKeyViolation); ok {
+		} else if _, ok := errors.Cause(err).(store.ErrFKeyViolation); ok {
 			ihttp.Error(w, http.StatusUnprocessableEntity)
 			return
 		} else if err != nil {

--- a/internal/store/realms.go
+++ b/internal/store/realms.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"database/sql"
-	"fmt"
 
 	"github.com/lib/pq"
 	"github.com/pkg/errors"
@@ -41,7 +40,7 @@ func (s *Service) GetRealm(id int64) (Realm, error) {
 	var realm Realm
 	err := s.db.Get(&realm, "SELECT * FROM realms WHERE id = $1", id)
 	if err == sql.ErrNoRows {
-		return realm, &ErrNoResults{msg: fmt.Sprintf("realm with id %d not found", id)}
+		return realm, ErrNoResults{errors.Wrapf(err, "realm with id %d not found", id)}
 	}
 	return realm, err
 }
@@ -50,7 +49,7 @@ func (s *Service) GetRealm(id int64) (Realm, error) {
 func (s *Service) InsertRealm(realm Realm) (int64, error) {
 	tx, err := s.db.Beginx()
 	if err != nil {
-		return -1, errors.Wrap(err, "unable to begin transaction")
+		return 0, errors.Wrap(err, "unable to begin transaction")
 	}
 
 	stmt, err := tx.PrepareNamed(`
@@ -60,16 +59,16 @@ func (s *Service) InsertRealm(realm Realm) (int64, error) {
     `)
 	if err != nil {
 		_ = tx.Rollback()
-		return -1, errors.Wrap(err, "unable to prepare realm insert statement")
+		return 0, errors.Wrap(err, "unable to prepare realm insert statement")
 	}
 
 	err = stmt.Get(&realm.ID, realm)
 	if err != nil {
 		_ = tx.Rollback()
 		if err, ok := err.(*pq.Error); ok && err.Code == pgExists {
-			return -1, &ErrExists{msg: fmt.Sprintf("realm with name: %s already exists", realm.Name)}
+			return 0, ErrExists{errors.Wrapf(err, "realm with name: %s already exists", realm.Name)}
 		}
-		return -1, errors.Wrap(err, "unable to insert realm")
+		return 0, errors.Wrap(err, "unable to insert realm")
 	}
 
 	return realm.ID, tx.Commit()
@@ -115,7 +114,7 @@ func (s *Service) PatchRealm(realm PatchRealm) error {
 
 	if count, err := result.RowsAffected(); err != nil || count == 0 {
 		_ = tx.Rollback()
-		return &ErrNoResults{msg: fmt.Sprintf("realm %d not found", realm.ID)}
+		return ErrNoResults{errors.Wrapf(err, "realm %d not found", realm.ID)}
 	}
 
 	return errors.Wrap(tx.Commit(), "unable to patch realm")

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -3,6 +3,7 @@ package store
 import (
 	"database/sql/driver"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -12,29 +13,17 @@ import (
 
 // ErrNoResults indicates that no data matching the query was found.
 type ErrNoResults struct {
-	msg string
-}
-
-func (enr *ErrNoResults) Error() string {
-	return enr.msg
+	error
 }
 
 // ErrExists is returned if a unique record already exists.
 type ErrExists struct {
-	msg string
-}
-
-func (eex *ErrExists) Error() string {
-	return eex.msg
+	error
 }
 
 // ErrFKeyViolation is returned if inserting a record causes a foreign key violation.
 type ErrFKeyViolation struct {
-	msg string
-}
-
-func (efk *ErrFKeyViolation) Error() string {
-	return efk.msg
+	error
 }
 
 const pgExists = "23505"
@@ -62,7 +51,7 @@ func (s *Service) Ping() error {
 		return s.db.QueryRow("SELECT 1").Scan(new(bool))
 	}
 
-	return fmt.Errorf("not connected to postgresql")
+	return errors.New("not connected to postgresql")
 }
 
 // Close closes the underlying postgresql database.
@@ -99,7 +88,7 @@ func NewUnixFromInt(time int64) UnixTime {
 // a unix timestamp.
 func (ut *UnixTime) Scan(src interface{}) error {
 	if ut == nil {
-		return fmt.Errorf("cannot scan into nil unix time")
+		return errors.New("cannot scan into nil unix time")
 	}
 
 	switch v := src.(type) {

--- a/internal/tba/tba.go
+++ b/internal/tba/tba.go
@@ -149,7 +149,7 @@ func (s *Service) GetEvents(year int) ([]store.Event, error) {
 	}
 
 	if response.StatusCode != http.StatusOK {
-		return nil, errors.Wrapf(err, "got unexpected status: %d", response.StatusCode)
+		return nil, fmt.Errorf("got unexpected status: %d", response.StatusCode)
 	}
 
 	var tbaEvents []event
@@ -223,7 +223,7 @@ func (s *Service) GetMatches(eventKey string) ([]store.Match, error) {
 	}
 
 	if response.StatusCode != http.StatusOK {
-		return nil, errors.Wrapf(err, "got unexpected status: %d", response.StatusCode)
+		return nil, fmt.Errorf("got unexpected status: %d", response.StatusCode)
 	}
 
 	var tbaMatches []match
@@ -287,7 +287,7 @@ func (s *Service) GetTeamKeys(eventKey string) ([]string, error) {
 	}
 
 	if response.StatusCode != http.StatusOK {
-		return nil, errors.Wrapf(err, "got unexpected status: %d", response.StatusCode)
+		return nil, fmt.Errorf("got unexpected status: %d", response.StatusCode)
 	}
 
 	var teamKeys []string
@@ -305,7 +305,7 @@ func (s *Service) GetTeamRankings(eventKey string) ([]store.Team, error) {
 	}
 
 	if response.StatusCode != http.StatusOK {
-		return nil, errors.Wrapf(err, "got unexpected status: %d", response.StatusCode)
+		return nil, fmt.Errorf("got unexpected status: %d", response.StatusCode)
 	}
 
 	teamRankings := rankings{

--- a/internal/tba/tba.go
+++ b/internal/tba/tba.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Pigmice2733/peregrine-backend/internal/store"
+	"github.com/pkg/errors"
 )
 
 // Service provides an interface to retrieve data from
@@ -85,7 +86,9 @@ var tbaClient = &http.Client{
 
 // ErrNotModified is returned when a resource has not been modified since it was
 // last retrieved from TBA.
-type ErrNotModified error
+type ErrNotModified struct {
+	error
+}
 
 func (s *Service) makeRequest(path string) (*http.Response, error) {
 	req, err := http.NewRequest("GET", s.URL+path, nil)
@@ -109,7 +112,7 @@ func (s *Service) makeRequest(path string) (*http.Response, error) {
 	}
 
 	if resp.StatusCode == http.StatusNotModified {
-		return resp, ErrNotModified(fmt.Errorf("tba: got not modified for path: %s", path))
+		return resp, ErrNotModified{fmt.Errorf("got not modified for path: %s", path)}
 	}
 
 	if etag := resp.Header.Get("etag"); etag != "" {
@@ -127,7 +130,7 @@ func webcastURL(webcastType store.WebcastType, channel string) (string, error) {
 		return fmt.Sprintf("https://www.youtube.com/watch?v=%s", channel), nil
 	}
 
-	return "", fmt.Errorf("got invalid webcast url")
+	return "", errors.New("got invalid webcast url")
 }
 
 // Ping pings the TBA /status endpoint
@@ -142,11 +145,11 @@ func (s *Service) GetEvents(year int) ([]store.Event, error) {
 
 	response, err := s.makeRequest(path)
 	if err != nil {
-		return nil, fmt.Errorf("TBA request to %s failed: %v", path, err)
+		return nil, errors.Wrap(err, "failed to make request")
 	}
 
 	if response.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("TBA request to %s failed with status code: %v", path, response.StatusCode)
+		return nil, errors.Wrapf(err, "got unexpected status: %d", response.StatusCode)
 	}
 
 	var tbaEvents []event
@@ -216,11 +219,11 @@ func (s *Service) GetMatches(eventKey string) ([]store.Match, error) {
 
 	response, err := s.makeRequest(path)
 	if err != nil {
-		return nil, fmt.Errorf("TBA request to %s failed: %v", path, err)
+		return nil, errors.Wrap(err, "failed to make request")
 	}
 
 	if response.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("TBA request to %s failed with status code: %v", path, response.StatusCode)
+		return nil, errors.Wrapf(err, "got unexpected status: %d", response.StatusCode)
 	}
 
 	var tbaMatches []match
@@ -280,11 +283,11 @@ func (s *Service) GetTeamKeys(eventKey string) ([]string, error) {
 
 	response, err := s.makeRequest(path)
 	if err != nil {
-		return nil, fmt.Errorf("TBA request to %s failed: %v", path, err)
+		return nil, errors.Wrap(err, "failed to make request")
 	}
 
 	if response.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("TBA request to %s failed with status code: %v", path, response.StatusCode)
+		return nil, errors.Wrapf(err, "got unexpected status: %d", response.StatusCode)
 	}
 
 	var teamKeys []string
@@ -298,11 +301,11 @@ func (s *Service) GetTeamRankings(eventKey string) ([]store.Team, error) {
 
 	response, err := s.makeRequest(path)
 	if err != nil {
-		return nil, fmt.Errorf("TBA request to %s failed: %v", path, err)
+		return nil, errors.Wrap(err, "failed to make request")
 	}
 
 	if response.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("TBA request to %s failed with status code: %v", path, response.StatusCode)
+		return nil, errors.Wrapf(err, "got unexpected status: %d", response.StatusCode)
 	}
 
 	teamRankings := rankings{


### PR DESCRIPTION
# Goal
Error housekeeping: wrap errors more/better, use errors.New, etc. Mostly nitpicky small stuff, but some important stuff like making sure to call `errors.Cause` on an error before checking if it's some type.

# Testing
API tests, unit tests.

![giphy 2](https://user-images.githubusercontent.com/32021905/49323525-874b4780-f4d1-11e8-9b73-5d3c07a15d71.gif)