### PR TITLE
Fix CORS, log middleware, bump JWT expiry

### DIFF
--- a/internal/http/middleware.go
+++ b/internal/http/middleware.go
@@ -42,6 +42,10 @@ type recorder struct {
 }
 
 func (r *recorder) Write(b []byte) (int, error) {
+	if r.code == 0 {
+		r.code = http.StatusOK
+	}
+
 	n, err := r.ResponseWriter.Write(b)
 	r.len += n
 	return n, err

--- a/internal/http/middleware.go
+++ b/internal/http/middleware.go
@@ -89,10 +89,10 @@ func Log(next http.Handler, l *logrus.Logger) http.HandlerFunc {
 }
 
 // Auth returns a middleware used for jwt authentication.
-func Auth(next http.HandlerFunc, jwtSecret []byte) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
+func Auth(next http.Handler, jwtSecret []byte) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") == "" {
-			next(w, r)
+			next.ServeHTTP(w, r)
 			return
 		}
 
@@ -124,8 +124,8 @@ func Auth(next http.HandlerFunc, jwtSecret []byte) http.HandlerFunc {
 		ctx = context.WithValue(ctx, keySubjectContext, claims.Subject)
 		ctx = context.WithValue(ctx, keyRealmContext, claims.RealmID)
 
-		next(w, r.WithContext(ctx))
-	}
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
 }
 
 // ACL returns a middleware that must be used inside of an Auth middleware for

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -28,7 +28,13 @@ type Server struct {
 // Run starts the server, and returns if it runs into an error
 func (s *Server) Run(ctx context.Context) error {
 	router := s.registerRoutes()
-	handler := ihttp.Auth(ihttp.Log(gziphandler.GzipHandler(ihttp.CORS(ihttp.LimitBody(router), s.Origin)), s.Logger), s.JWTSecret)
+
+	var handler http.Handler = router
+	handler = ihttp.LimitBody(handler)
+	handler = gziphandler.GzipHandler(handler)
+	handler = ihttp.Auth(handler, s.JWTSecret)
+	handler = ihttp.Log(handler, s.Logger)
+	handler = ihttp.CORS(handler, s.Origin)
 
 	s.Logger.Info("fetching seed events")
 	if err := s.updateEvents(ctx); err != nil {

--- a/internal/server/users.go
+++ b/internal/server/users.go
@@ -30,8 +30,8 @@ type requestUser struct {
 }
 
 const (
-	accessTokenDuration  = time.Hour * 8      // 8 hours
-	refreshTokenDuration = time.Hour * 24 * 7 // 7 days
+	accessTokenDuration  = time.Hour * 24         // 1 day
+	refreshTokenDuration = time.Hour * 24 * 7 * 2 // 2 weeks
 )
 
 func (s *Server) authenticateHandler() http.HandlerFunc {


### PR DESCRIPTION
# Goal
Fix CORS headers not being sent if something goes wrong with auth, fix log middleware sending a 0 status code (closes #145), bump up JWT expiry time for access and refresh token.