### PR TITLE
Allow JWT secret to be set via the config file

### DIFF
--- a/cmd/peregrine/main.go
+++ b/cmd/peregrine/main.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Pigmice2733/peregrine-backend/internal/server"
 	"github.com/Pigmice2733/peregrine-backend/internal/store"
 	"github.com/Pigmice2733/peregrine-backend/internal/tba"
-	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -53,22 +52,11 @@ func run(basePath string) error {
 		c.Server.Year = time.Now().Year()
 	}
 
-	secret := c.Server.Secret
-	if secret == "" {
-		secretUUID, err := uuid.NewRandom()
-		if err != nil {
-			return errors.Wrap(err, "unable to generate uuid for secret")
-		}
-
-		secret = secretUUID.String()
-	}
-
 	s := &server.Server{
-		TBA:       tba,
-		Store:     sto,
-		Logger:    logger,
-		Server:    c.Server,
-		JWTSecret: []byte(secret),
+		TBA:    tba,
+		Store:  sto,
+		Logger: logger,
+		Server: c.Server,
 	}
 
 	return errors.Wrap(s.Run(context.Background()), "running server")

--- a/cmd/peregrine/main.go
+++ b/cmd/peregrine/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"crypto/rand"
 	"flag"
 	"fmt"
 	"os"
@@ -12,6 +11,7 @@ import (
 	"github.com/Pigmice2733/peregrine-backend/internal/server"
 	"github.com/Pigmice2733/peregrine-backend/internal/store"
 	"github.com/Pigmice2733/peregrine-backend/internal/tba"
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -53,9 +53,14 @@ func run(basePath string) error {
 		c.Server.Year = time.Now().Year()
 	}
 
-	jwtSecret := make([]byte, 64)
-	if _, err := rand.Read(jwtSecret); err != nil {
-		return errors.Wrap(err, "generating jwt secret")
+	secret := c.Server.Secret
+	if secret == "" {
+		secretUUID, err := uuid.NewRandom()
+		if err != nil {
+			return errors.Wrap(err, "unable to generate uuid for secret")
+		}
+
+		secret = secretUUID.String()
 	}
 
 	s := &server.Server{
@@ -63,7 +68,7 @@ func run(basePath string) error {
 		Store:     sto,
 		Logger:    logger,
 		Server:    c.Server,
-		JWTSecret: jwtSecret,
+		JWTSecret: []byte(secret),
 	}
 
 	return errors.Wrap(s.Run(context.Background()), "running server")

--- a/etc/config.yaml.template.full
+++ b/etc/config.yaml.template.full
@@ -1,0 +1,15 @@
+server:
+    httpAddress: 0.0.0.0:8080 # no default, required
+    httpsAddress: 0.0.0.0:8081 # no default, not required
+    keyFile: /etc/letsencrypt/live/edge.api.peregrine.ga/fullchain.pem # no default, required if httpsAddress set
+    certFile: /etc/letsencrypt/live/edge.api.peregrine.ga/fullchain.pem # no default, required if httpsAddress set
+    origin: "*" # default, not required
+    year: 2019 # defaults current year, not required
+    logJSON: false # default, not required
+    secret: dbf223b6-1633-11e9-b84a-9cb6d08abbe3 # default random uuid, not required
+
+tba:
+    url: https://www.thebluealliance.com/api/v3 # default, not required
+    apiKey: your-api-key # no default, required
+
+dsn: user=postgres port=5432 dbname=peregrine sslmode=disable

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/go-playground/locales v0.12.1 // indirect
 	github.com/go-playground/universal-translator v0.16.0 // indirect
 	github.com/golang-migrate/migrate v3.5.4+incompatible
+	github.com/google/uuid v1.1.0
 	github.com/gorilla/context v1.1.1 // indirect
 	github.com/gorilla/mux v1.6.2
 	github.com/jmoiron/sqlx v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG
 github.com/golang-migrate/migrate v3.5.4+incompatible h1:R7OzwvCJTCgwapPCiX6DyBiu2czIUMDCB118gFTKTUA=
 github.com/golang-migrate/migrate v3.5.4+incompatible/go.mod h1:IsVUlFN5puWOmXrqjgGUfIRIbU7mr8oNBE2tyERd9Wk=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/google/uuid v1.1.0 h1:Jf4mxPC/ziBnoPIdpQdPJ9OeiomAUHLvxmPRSPH9m4s=
+github.com/google/uuid v1.1.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/context v1.1.1 h1:AWwleXJkX/nhcU9bZSnZoi3h/qGYqQAGhq6zZe/aQW8=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v1.6.2 h1:Pgr17XVTNXAk3q/r4CpKzC5xBM/qW1uVLV+IhRZpIIk=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@ type Server struct {
 	Origin       string `yaml:"origin"`
 	Year         int    `yaml:"year"`
 	LogJSON      bool   `yaml:"logJSON"`
+	Secret       string `yaml:"secret"`
 }
 
 // Config holds information about how the peregrine backend is configured.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"path"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 )
@@ -43,16 +44,19 @@ func Open(basePath string) (Config, error) {
 	viper.AddConfigPath(path.Join(basePath, "etc"))
 	viper.SetConfigName("config." + environment)
 
+	secretUUID, err := uuid.NewRandom()
+	if err != nil {
+		return Config{}, errors.Wrap(err, "unable to generate uuid for secret")
+	}
+
 	viper.SetDefault("server", map[string]interface{}{
 		"httpAddress": ":8080",
 		"origin":      "*",
 		"year":        time.Now().Year(),
 		"logJSON":     false,
+		"secret":      secretUUID.String(),
 	})
 	viper.SetDefault("tba.url", "https://www.thebluealliance.com/api/v3")
-	if err := viper.BindEnv("tba.apiKey", "PEREGRINE_TBA_API_KEY"); err != nil {
-		return Config{}, errors.Wrap(err, "unable to bind viper env var for api key")
-	}
 
 	if err := viper.ReadInConfig(); err != nil {
 		return Config{}, errors.Wrap(err, "unable to read in config file")

--- a/internal/http/middleware.go
+++ b/internal/http/middleware.go
@@ -93,7 +93,7 @@ func Log(next http.Handler, l *logrus.Logger) http.HandlerFunc {
 }
 
 // Auth returns a middleware used for jwt authentication.
-func Auth(next http.Handler, jwtSecret []byte) http.Handler {
+func Auth(next http.Handler, secret string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") == "" {
 			next.ServeHTTP(w, r)
@@ -106,7 +106,7 @@ func Auth(next http.Handler, jwtSecret []byte) http.Handler {
 				return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 			}
 
-			return jwtSecret, nil
+			return secret, nil
 		})
 		if err != nil {
 			Error(w, http.StatusUnauthorized)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -20,7 +20,6 @@ type Server struct {
 	TBA              tba.Service
 	Store            store.Service
 	Logger           *logrus.Logger
-	JWTSecret        []byte
 	eventsLastUpdate *time.Time
 	start            time.Time
 }
@@ -33,7 +32,7 @@ func (s *Server) Run(ctx context.Context) error {
 	handler = ihttp.LimitBody(handler)
 	handler = gziphandler.GzipHandler(handler)
 	handler = ihttp.Log(handler, s.Logger)
-	handler = ihttp.Auth(handler, s.JWTSecret)
+	handler = ihttp.Auth(handler, s.Secret)
 	handler = ihttp.CORS(handler, s.Origin)
 
 	s.Logger.Info("fetching seed events")


### PR DESCRIPTION
# Goal
Allow JWT secret to be set via the config file so if we restart the server all existing JWTs don't get invalidated. If a JWT isn't set in the config file, a random UUID will be generated to be used as the secret.
<!-- Description of what the PR is trying to accomplish. -->

# Testing
Try setting a secret in the config file, try not setting one.