### PR TITLE
Serve empty (not nil) auto/teleop slices on the stat endpoint

### DIFF
--- a/internal/server/stats.go
+++ b/internal/server/stats.go
@@ -86,7 +86,7 @@ func (s *Server) eventStats() http.HandlerFunc {
 
 		fullStats := make([]teamStats, 0)
 		for _, ts := range analyzedStats {
-			stats := teamStats{Team: ts.Team}
+			stats := teamStats{Team: ts.Team, Auto: make([]interface{}, 0), Teleop: make([]interface{}, 0)}
 
 			for _, v := range ts.AutoBoolean {
 				stats.Auto = append(stats.Auto, v)


### PR DESCRIPTION
# Goal
Because JS has an aneurysm when it gets a `null` instead of `[]` array.
<!-- Description of what the PR is trying to accomplish. -->

# Testing
jest
<!-- Description of how the PR should be tested. -->

