### PR TITLE
Add GMaps URL to events

### DIFF
--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -23,6 +23,7 @@ type Event struct {
 	EndDate      time.Time      `json:"endDate" db:"end_date"`
 	Webcasts     pq.StringArray `json:"webcasts" db:"webcasts"`
 	LocationName string         `json:"locationName" db:"location_name"`
+	GMapsURL     *string        `json:"gmapsUrl" db:"gmaps_url"`
 	Lat          float64        `json:"lat" db:"lat"`
 	Lon          float64        `json:"lon" db:"lon"`
 	TBADeleted   bool           `json:"tbaDeleted" db:"tba_deleted"`
@@ -39,6 +40,7 @@ SELECT
 		end_date,
 		webcasts,
 		location_name,
+		gmaps_url,
 		lat,
 		lon,
 		tba_deleted,
@@ -118,8 +120,8 @@ func (s *Service) EventsUpsert(ctx context.Context, events []Event) error {
 	}
 
 	eventStmt, err := tx.PrepareNamedContext(ctx, `
-		INSERT INTO events (key, name, district, full_district, week, start_date, end_date, webcasts, location_name, lat, lon, realm_id, schema_id, tba_deleted)
-		VALUES (:key, :name, :district, :full_district, :week, :start_date, :end_date, :webcasts, :location_name, :lat, :lon, :realm_id, :schema_id, :tba_deleted)
+		INSERT INTO events (key, name, district, full_district, week, start_date, end_date, webcasts, location_name, gmaps_url, lat, lon, realm_id, schema_id, tba_deleted)
+		VALUES (:key, :name, :district, :full_district, :week, :start_date, :end_date, :webcasts, :location_name, :gmaps_url, :lat, :lon, :realm_id, :schema_id, :tba_deleted)
 		ON CONFLICT (key)
 		DO
 			UPDATE
@@ -132,6 +134,7 @@ func (s *Service) EventsUpsert(ctx context.Context, events []Event) error {
 					end_date = :end_date,
 					webcasts = :webcasts,
 					location_name = :location_name,
+					gmaps_url = :gmaps_url,
 					lat = :lat,
 					lon = :lon,
 					realm_id = :realm_id,
@@ -202,8 +205,8 @@ func (s *Service) UpsertEvent(ctx context.Context, event Event) (created bool, e
 	}
 
 	_, err = tx.NamedExecContext(ctx, `
-		INSERT INTO events (key, name, district, full_district, week, start_date, end_date, webcasts, location_name, lat, lon, realm_id, schema_id, tba_deleted)
-		VALUES (:key, :name, :district, :full_district, :week, :start_date, :end_date, :webcasts, :location_name, :lat, :lon, :realm_id, :schema_id, :tba_deleted)
+		INSERT INTO events (key, name, district, full_district, week, start_date, end_date, webcasts, location_name, gmaps_url, lat, lon, realm_id, schema_id, tba_deleted)
+		VALUES (:key, :name, :district, :full_district, :week, :start_date, :end_date, :webcasts, :location_name, :gmaps_url, :lat, :lon, :realm_id, :schema_id, :tba_deleted)
 		ON CONFLICT (key)
 		DO
 			UPDATE
@@ -216,6 +219,7 @@ func (s *Service) UpsertEvent(ctx context.Context, event Event) (created bool, e
 					end_date = :end_date,
 					webcasts = :webcasts,
 					location_name = :location_name,
+					gmaps_url= :gmaps_url,
 					lat = :lat,
 					lon = :lon,
 					realm_id = :realm_id,

--- a/internal/tba/tba.go
+++ b/internal/tba/tba.go
@@ -38,6 +38,7 @@ type event struct {
 	District     *district `json:"district"`
 	Lat          float64   `json:"lat"`
 	Lng          float64   `json:"lng"`
+	GMapsURL     *string   `json:"gmaps_url"`
 	LocationName string    `json:"location_name"`
 	Week         *int      `json:"week"`
 	StartDate    string    `json:"start_date"`
@@ -211,6 +212,7 @@ func (s *Service) GetEvents(ctx context.Context, year int, schemaID *int64) ([]s
 			Webcasts:     webcasts,
 			Lat:          tbaEvent.Lat,
 			Lon:          tbaEvent.Lng,
+			GMapsURL:     tbaEvent.GMapsURL,
 			LocationName: tbaEvent.LocationName,
 			SchemaID:     schemaID,
 		})

--- a/internal/tba/tba_test.go
+++ b/internal/tba/tba_test.go
@@ -102,6 +102,7 @@ func TestGetEvents(t *testing.T) {
 						],
 						"lat": 41.9911025,
 						"lng": -70.993044,
+						"gmaps_url": "https://www.google.com/maps?cid=7437893320196269298",
 						"location_name": "location1",
 						"timezone": "America/Los_Angeles"
 					}
@@ -123,6 +124,7 @@ func TestGetEvents(t *testing.T) {
 					EndDate:      time.Date(2018, 4, 4, 7, 0, 0, 0, time.UTC),
 					Lat:          41.9911025,
 					Lon:          -70.993044,
+					GMapsURL:     newString("https://www.google.com/maps?cid=7437893320196269298"),
 					LocationName: "location1",
 					Webcasts:     []string{"https://www.twitch.tv/nefirst_blue"},
 				},
@@ -161,6 +163,7 @@ func TestGetEvents(t *testing.T) {
 					    ],
 						"lat": 42.0,
 						"lng": 0.0,
+						"gmaps_url": "https://www.google.com/maps?cid=7437893320196269298",
 						"location_name": "answer"
 					},
 					{
@@ -187,6 +190,7 @@ func TestGetEvents(t *testing.T) {
 							}],
 						"lat": 45.52,
 						"lng": -122.681944,
+						"gmaps_url": "https://www.google.com/maps?cid=7437893320196269298",
 						"location_name": "Portland",
 						"timezone": "America/Los_Angeles"
 				    }
@@ -207,6 +211,7 @@ func TestGetEvents(t *testing.T) {
 				EndDate:      time.Date(2018, 5, 7, 0, 0, 0, 0, time.UTC),
 				Lat:          42.0,
 				Lon:          0.0,
+				GMapsURL:     newString("https://www.google.com/maps?cid=7437893320196269298"),
 				LocationName: "answer",
 				Webcasts:     []string{"https://www.youtube.com/watch?v=rXP6Vz9-Jjg", "https://www.twitch.tv/firstinspires12"},
 			}, {
@@ -219,6 +224,7 @@ func TestGetEvents(t *testing.T) {
 				EndDate:      time.Date(2018, 11, 23, 8, 0, 0, 0, time.UTC),
 				Lat:          45.52,
 				Lon:          -122.681944,
+				GMapsURL:     newString("https://www.google.com/maps?cid=7437893320196269298"),
 				LocationName: "Portland",
 				Webcasts:     []string{"https://www.youtube.com/watch?v=gmsHpsSavuc"},
 			}},
@@ -586,6 +592,7 @@ func TestGetTeams(t *testing.T) {
 						"key": "frc7500",
 						"lat": null,
 						"lng": null,
+						"gmaps_url": null,
 						"location_name": null,
 						"motto": null,
 						"name": "NASA/Florida Power and Light/State of Florida&St Thomas Aquinas High School",
@@ -609,6 +616,7 @@ func TestGetTeams(t *testing.T) {
 						"key": "frc7502",
 						"lat": null,
 						"lng": null,
+						"gmaps_url": null,
 						"location_name": null,
 						"motto": null,
 						"name": "NASA/Middlebury Community Schools&Northridge High School",
@@ -637,6 +645,7 @@ func TestGetTeams(t *testing.T) {
 						"key": "frc2733",
 						"lat": null,
 						"lng": null,
+						"gmaps_url": null,
 						"location_name": null,
 						"motto": null,
 						"name": "Daimler/TE Connectivity/Boeing/Oregon Dept of Education/FLIR/Autodesk/DW Fritz Automation/Marathon Oil/SolidWorks/Hankins Hardware&Cleveland High School&Family/Community",

--- a/migrations/24_add_gmaps_url.down.sql
+++ b/migrations/24_add_gmaps_url.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE events DROP COLUMN gmaps_url;

--- a/migrations/24_add_gmaps_url.up.sql
+++ b/migrations/24_add_gmaps_url.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE events ADD COLUMN gmaps_url TEXT;


### PR DESCRIPTION
# Goal

Add Google Maps URLs to events so frontend can link to actual event location rather than just plug lat/lon into Maps.

# Testing

Unit tests

