### PR TITLE
Match editing/deletion

### DIFF
--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -33,8 +33,9 @@ func (s *Server) registerRoutes() *mux.Router {
 	r.Handle("/events/{eventKey}/stats", s.eventStats()).Methods("GET")
 
 	r.Handle("/events/{eventKey}/matches", s.matchesHandler()).Methods("GET")
-	r.Handle("/events/{eventKey}/matches", ihttp.ACL(s.createMatchHandler(), true, true, true)).Methods("POST")
 	r.Handle("/events/{eventKey}/matches/{matchKey}", s.matchHandler()).Methods("GET")
+	r.Handle("/events/{eventKey}/matches/{matchKey}", ihttp.ACL(s.upsertMatchHandler(), true, true, true)).Methods("PUT")
+	r.Handle("/events/{eventKey}/matches/{matchKey}", ihttp.ACL(s.deleteMatchHandler(), true, true, true)).Methods("DELETE")
 
 	r.Handle("/events/{eventKey}/teams", s.eventTeamsHandler()).Methods("GET")
 	r.Handle("/events/{eventKey}/teams/{teamKey}", s.eventTeamHandler()).Methods("GET")

--- a/internal/tba/tba.go
+++ b/internal/tba/tba.go
@@ -273,6 +273,8 @@ func (s *Service) GetMatches(ctx context.Context, eventKey string) ([]store.Matc
 			blueScore = tbaMatch.Alliances.Blue.Score
 		}
 
+		matchURL := fmt.Sprintf("https://www.thebluealliance.com/match/%s", tbaMatch.Key)
+
 		match := store.Match{
 			Key:                tbaMatch.Key,
 			EventKey:           eventKey,
@@ -285,7 +287,9 @@ func (s *Service) GetMatches(ctx context.Context, eventKey string) ([]store.Matc
 			BlueAlliance:       tbaMatch.Alliances.Blue.TeamKeys,
 			RedScoreBreakdown:  tbaMatch.ScoreBreakdown.Red,
 			BlueScoreBreakdown: tbaMatch.ScoreBreakdown.Blue,
+			TBAURL:             &matchURL,
 		}
+
 		matches = append(matches, match)
 	}
 

--- a/internal/tba/tba_test.go
+++ b/internal/tba/tba_test.go
@@ -361,6 +361,7 @@ func TestGetMatches(t *testing.T) {
 					BlueAlliance:       []string{"frc2733", "frc9876", "frc1"},
 					RedScoreBreakdown:  map[string]interface{}{"foobar": 3.0, "barbaz": true},
 					BlueScoreBreakdown: map[string]interface{}{"foobar": 1.0, "blabla": 3.212},
+					TBAURL:             newString("https://www.thebluealliance.com/match/key1"),
 				},
 				{
 					Key:                "key2",
@@ -374,6 +375,7 @@ func TestGetMatches(t *testing.T) {
 					BlueAlliance:       []string{"frc2", "frc7", "frc3"},
 					RedScoreBreakdown:  map[string]interface{}{"foobar": 90.2, "barbaz": false},
 					BlueScoreBreakdown: map[string]interface{}{"foobar": 4.2321, "blabla": 9.0},
+					TBAURL:             newString("https://www.thebluealliance.com/match/key2"),
 				},
 			},
 			expectErr: false,
@@ -445,6 +447,7 @@ func TestGetMatches(t *testing.T) {
 					BlueScore:     nil,
 					RedAlliance:   []string{"frc254", "frc1234", "frc00"},
 					BlueAlliance:  []string{"frc2733", "frc9876", "frc1"},
+					TBAURL:        newString("https://www.thebluealliance.com/match/key1"),
 				},
 				{
 					Key:           "key2",
@@ -456,6 +459,7 @@ func TestGetMatches(t *testing.T) {
 					BlueScore:     nil,
 					RedAlliance:   []string{"frc0", "frc1", "frc2"},
 					BlueAlliance:  []string{"frc2", "frc7", "frc3"},
+					TBAURL:        newString("https://www.thebluealliance.com/match/key2"),
 				},
 			},
 			expectErr: false,

--- a/migrations/27_add_tba_match_url.down.sql
+++ b/migrations/27_add_tba_match_url.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE matches DROP COLUMN tba_url;

--- a/migrations/27_add_tba_match_url.up.sql
+++ b/migrations/27_add_tba_match_url.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE matches ADD COLUMN tba_url TEXT;


### PR DESCRIPTION
Add TBA URL to TBA matches
Validate that alliances on PUT matches are not null
Move match edit/create to PUT endpoint
Add match deletion endpoint

Presence of TBA URL on match indicates match is a TBA match, not a custom one. TBA matches that are deleted/edited will be overwritten by TBA every 15 minutes for past/future events, and every minute for active events.

Closes #104 