### PR TITLE
Fix the match team stats endpoint

### DIFF
--- a/internal/server/reports.go
+++ b/internal/server/reports.go
@@ -28,7 +28,7 @@ func (s *Server) getReports() http.HandlerFunc {
 			realmID = &userRealmID
 		}
 
-		reports, err := s.Store.GetMatchTeamReportsForRealm(r.Context(), matchKey, teamKey, realmID)
+		reports, err := s.Store.GetMatchTeamReportsForRealm(r.Context(), eventKey, matchKey, teamKey, realmID)
 		if err != nil {
 			ihttp.Error(w, http.StatusInternalServerError)
 			s.Logger.WithError(err).Error("getting reports")

--- a/internal/server/stats.go
+++ b/internal/server/stats.go
@@ -55,7 +55,7 @@ func (s *Server) eventStats() http.HandlerFunc {
 			return
 		}
 
-		storeMatches, err := s.Store.GetAnalysisInfoForRealm(r.Context(), eventKey, realmID)
+		storeMatches, err := s.Store.GetEventAnalysisInfoForRealm(r.Context(), eventKey, realmID)
 		if err != nil {
 			ihttp.Error(w, http.StatusInternalServerError)
 			s.Logger.WithError(err).Error("retrieving match analysis info")
@@ -112,7 +112,7 @@ func (s *Server) matchTeamStats() http.HandlerFunc {
 		// Add eventKey as prefix to matchKey so that matchKey is globally
 		// unique and consistent with TBA match keys.
 		matchKey := fmt.Sprintf("%s_%s", eventKey, partialMatchKey)
-		match, err := s.Store.GetMatchForRealm(r.Context(), matchKey, realmID)
+		match, err := s.Store.GetMatchAnalysisInfoForRealm(r.Context(), eventKey, matchKey, realmID)
 		if errors.Is(err, store.ErrNoResults{}) {
 			ihttp.Error(w, http.StatusNotFound)
 			return
@@ -122,7 +122,7 @@ func (s *Server) matchTeamStats() http.HandlerFunc {
 			return
 		}
 
-		reports, err := s.Store.GetMatchTeamReportsForRealm(r.Context(), eventKey, teamKey, realmID)
+		reports, err := s.Store.GetMatchTeamReportsForRealm(r.Context(), eventKey, matchKey, teamKey, realmID)
 		if err != nil {
 			ihttp.Error(w, http.StatusInternalServerError)
 			s.Logger.WithError(err).Error("retrieving reports")

--- a/internal/store/reports.go
+++ b/internal/store/reports.go
@@ -124,19 +124,20 @@ func (s *Service) GetEventTeamReportsForRealm(ctx context.Context, eventKey stri
 
 // GetMatchTeamReportsForRealm retrieves all reports for a specific team and event, filtering to only retrieve reports for realms
 // that are sharing reports or have a matching realm ID.
-func (s *Service) GetMatchTeamReportsForRealm(ctx context.Context, matchKey string, teamKey string, realmID *int64) (reports []Report, err error) {
+func (s *Service) GetMatchTeamReportsForRealm(ctx context.Context, eventKey, matchKey string, teamKey string, realmID *int64) (reports []Report, err error) {
 	const query = `
 	SELECT reports.*
 	FROM reports
 	INNER JOIN realms
 		ON realms.id = reports.realm_id
 	WHERE
-		reports.match_key = $1 AND
-		reports.team_key = $2 AND
-		(realms.share_reports = true OR realms.id = $3)`
+		reports.event_key = $1 AND
+		reports.match_key = $2 AND
+		reports.team_key = $3 AND
+		(realms.share_reports = true OR realms.id = $4)`
 
 	reports = make([]Report, 0)
-	return reports, s.db.SelectContext(ctx, &reports, query, matchKey, teamKey, realmID)
+	return reports, s.db.SelectContext(ctx, &reports, query, eventKey, matchKey, teamKey, realmID)
 }
 
 // GetLeaderboardForRealm retrieves leaderboard information from the reports and users table for users


### PR DESCRIPTION
# Goal

It was using the event key as the match key when getting reports in the match team stats endpoint. Fix that.