### PR TITLE
Return all events from /events

### DIFF
--- a/internal/server/events.go
+++ b/internal/server/events.go
@@ -3,11 +3,9 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
-	"strconv"
-
-	"errors"
 
 	ihttp "github.com/Pigmice2733/peregrine-backend/internal/http"
 	"github.com/Pigmice2733/peregrine-backend/internal/store"
@@ -18,7 +16,7 @@ import (
 // eventsHandler returns a handler to get all events in a given year.
 func (s *Server) eventsHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		tbaDeleted, _ := strconv.ParseBool(r.URL.Query().Get("tbaDeleted"))
+		tbaDeleted := true
 
 		var realmID *int64
 		userRealmID, err := ihttp.GetRealmID(r)


### PR DESCRIPTION
Once this is merged, we can safely roll the year forward to 2020 without losing 2019 events from the home page. Temporary change, we don't want to still be returning 2018 data four years down the road.
