### PR TITLE
Admin report editing

### DIFF
--- a/internal/server/matches.go
+++ b/internal/server/matches.go
@@ -237,20 +237,3 @@ func editMatch(ctx context.Context, sto *store.Service, roles store.Roles, userR
 
 	return existed, err
 }
-
-type forbiddenError struct {
-	err error
-}
-
-func (f forbiddenError) Unwrap() error {
-	return f.err
-}
-
-func (f forbiddenError) Error() string {
-	return f.err.Error()
-}
-
-func (f forbiddenError) Is(target error) bool {
-	_, ok := target.(forbiddenError)
-	return ok
-}

--- a/internal/server/openapi.yaml
+++ b/internal/server/openapi.yaml
@@ -684,29 +684,6 @@ paths:
           $ref: "#/components/responses/notFoundError"
         "500":
           $ref: "#/components/responses/internalServerError"
-  /events/{eventKey}/teams/{teamKey}/comments:
-    parameters:
-      - $ref: "#/components/parameters/eventKey"
-      - $ref: "#/components/parameters/teamKey"
-    get:
-      summary: Get comments about a team at an event
-      operationId: getTeamEventComments
-      security:
-        - BearerAuth: []
-      tags:
-        - comments
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/comment"
-        "401":
-          $ref: "#/components/responses/unauthorizedError"
-        "500":
-          $ref: "#/components/responses/internalServerError"
   /events/{eventKey}/matches/{matchKey}/reports/{teamKey}:
     parameters:
       - $ref: "#/components/parameters/eventKey"

--- a/internal/server/openapi.yaml
+++ b/internal/server/openapi.yaml
@@ -768,12 +768,20 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/report"
+              $ref: "#/components/schemas/upload-report"
       responses:
         "201":
           description: Submitted new report
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/id"
         "204":
           description: Successfully replaced existing report
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/id"
         "401":
           $ref: "#/components/responses/unauthorizedError"
         "403":
@@ -790,6 +798,27 @@ paths:
           $ref: "#/components/schemas/id"
         required: true
         description: Numeric Report ID
+    get:
+      summary: Get report
+      operationId: getReport
+      security:
+        - BearerAuth: []
+      tags:
+        - reports
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/report"
+        "400":
+          $ref: "#/components/responses/badRequestError"
+        "401":
+          $ref: "#/components/responses/unauthorizedError"
+        "404":
+          $ref: "#/components/responses/notFoundError"
+        "500":
+          $ref: "#/components/responses/internalServerError"
     put:
       summary: Update existing report
       operationId: putReports
@@ -801,7 +830,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/report"
+              $ref: "#/components/schemas/upload-report"
       responses:
         "204":
           description: Successfully update existing report
@@ -1158,13 +1187,39 @@ components:
           example: 2
     report:
       required:
+        - id
+        - eventKey
+        - matchKey
+        - teamKey
         - data
+        - comment
+      properties:
+        id:
+          $ref: "#/components/schemas/id"
+        eventKey:
+          type: string
+          example: 2019abca
+        matchKey:
+          type: string
+          example: qm5
+        teamKey:
+          type: string
+          example: frc2733
+        realmId:
+          $ref: "#/components/schemas/id"
+        reporterId:
+          $ref: "#/components/schemas/id"
+        data:
+          $ref: "#/components/schemas/reportData"
+        comment:
+          type: string
+          example: "Played good defense"
+    upload-report:
+      required:
         - eventKey
         - matchKey
         - teamKey
       properties:
-        id:
-          $ref: "#/components/schemas/id"
         eventKey:
           type: string
           example: 2019abca

--- a/internal/server/openapi.yaml
+++ b/internal/server/openapi.yaml
@@ -716,22 +716,28 @@ paths:
           schema:
             type: string
             example: 2019abca
-          required: true
-          description: Get reports from a specific event
+          required: false
+          description: Get only reports from a specific event
         - in: query
           name: team
           schema:
             type: string
             example: frc2733
-          required: true
-          description: Get reports from a specific team
+          required: false
+          description: Get only reports from a specific team
         - in: query
           name: match
           schema:
             type: string
             example: qm2
           required: false
-          description: Get reports from a specific match
+          description: Get only reports from a specific match
+        - in: query
+          name: reporter
+          schema:
+            $ref: "#/components/schemas/id"
+          required: false
+          description: Get only reports from a specific user
       operationId: getReports
       security:
         - BearerAuth: []
@@ -1153,6 +1159,9 @@ components:
     report:
       required:
         - data
+        - eventKey
+        - matchKey
+        - teamKey
       properties:
         id:
           $ref: "#/components/schemas/id"
@@ -1332,7 +1341,6 @@ components:
       type: integer
       format: int64
       example: 1
-      readOnly: true
     schema:
       required:
         - id

--- a/internal/server/openapi.yaml
+++ b/internal/server/openapi.yaml
@@ -684,14 +684,55 @@ paths:
           $ref: "#/components/responses/notFoundError"
         "500":
           $ref: "#/components/responses/internalServerError"
-  /events/{eventKey}/matches/{matchKey}/reports/{teamKey}:
+  /events/{eventKey}/teams/{teamKey}/comments:
     parameters:
       - $ref: "#/components/parameters/eventKey"
-      - $ref: "#/components/parameters/matchKey"
       - $ref: "#/components/parameters/teamKey"
     get:
-      summary: Get reports for a team in a match at an event
-      operationId: getTeamMatchReports
+      summary: Get comments about a team at an event
+      operationId: getTeamEventComments
+      security:
+        - BearerAuth: []
+      tags:
+        - comments
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/comment"
+        "401":
+          $ref: "#/components/responses/unauthorizedError"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+  /reports:
+    get:
+      summary: Get reports
+      parameters:
+        - in: query
+          name: event
+          schema:
+            type: string
+            example: 2019abca
+          required: true
+          description: Get reports from a specific event
+        - in: query
+          name: team
+          schema:
+            type: string
+            example: frc2733
+          required: true
+          description: Get reports from a specific team
+        - in: query
+          name: match
+          schema:
+            type: string
+            example: qm2
+          required: false
+          description: Get reports from a specific match
+      operationId: getReports
       security:
         - BearerAuth: []
       tags:
@@ -704,17 +745,17 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/report"
+        "400":
+          $ref: "#/components/responses/badRequestError"
         "401":
           $ref: "#/components/responses/unauthorizedError"
-        "404":
-          $ref: "#/components/responses/notFoundError"
         "500":
           $ref: "#/components/responses/internalServerError"
-    put:
-      summary: Submit a report for a team in a match at an event
+    post:
+      summary: Submit a report
       security:
         - BearerAuth: []
-      operationId: postTeamMatchReport
+      operationId: postReport
       tags:
         - reports
       requestBody:
@@ -733,6 +774,59 @@ paths:
           $ref: "#/components/responses/forbiddenError"
         "422":
           $ref: "#/components/responses/unprocessableEntityError"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+  /reports/{id}:
+    parameters:
+      - in: path
+        name: id
+        schema:
+          $ref: "#/components/schemas/id"
+        required: true
+        description: Numeric Report ID
+    put:
+      summary: Update existing report
+      operationId: putReports
+      security:
+        - BearerAuth: []
+      tags:
+        - reports
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/report"
+      responses:
+        "204":
+          description: Successfully update existing report
+        "400":
+          $ref: "#/components/responses/badRequestError"
+        "401":
+          $ref: "#/components/responses/unauthorizedError"
+        "403":
+          $ref: "#/components/responses/forbiddenError"
+        "404":
+          $ref: "#/components/responses/notFoundError"
+        "422":
+          $ref: "#/components/responses/unprocessableEntityError"
+        "500":
+          $ref: "#/components/responses/internalServerError"
+    delete:
+      summary: Delete existing report
+      security:
+        - BearerAuth: []
+      operationId: deleteReport
+      tags:
+        - reports
+      responses:
+        "204":
+          description: Successfully deleted report
+        "401":
+          $ref: "#/components/responses/unauthorizedError"
+        "403":
+          $ref: "#/components/responses/forbiddenError"
+        "404":
+          $ref: "#/components/responses/notFoundError"
         "500":
           $ref: "#/components/responses/internalServerError"
   /events/{eventKey}/matches/{matchKey}/comments/{teamKey}:
@@ -1060,10 +1154,26 @@ components:
       required:
         - data
       properties:
+        id:
+          $ref: "#/components/schemas/id"
+        eventKey:
+          type: string
+          example: 2019abca
+        matchKey:
+          type: string
+          example: qm5
+        teamKey:
+          type: string
+          example: frc2733
+        realmId:
+          $ref: "#/components/schemas/id"
         reporterId:
           $ref: "#/components/schemas/id"
         data:
           $ref: "#/components/schemas/reportData"
+        comment:
+          type: string
+          example: "Played good defense"
     comment:
       required:
         - comment

--- a/internal/server/reports.go
+++ b/internal/server/reports.go
@@ -2,7 +2,9 @@ package server
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
+	"strconv"
 
 	"github.com/Pigmice2733/peregrine-backend/internal/store"
 
@@ -10,12 +12,15 @@ import (
 	"github.com/gorilla/mux"
 )
 
-func (s *Server) getReports() http.HandlerFunc {
+func (s *Server) getReportsHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		vars := mux.Vars(r)
-		eventKey := vars["eventKey"]
-		matchKey := vars["matchKey"]
-		teamKey := vars["teamKey"]
+		eventQuery := r.URL.Query().Get("event")
+		matchQuery := r.URL.Query().Get("match")
+		teamQuery := r.URL.Query().Get("team")
+
+		eventSpecified := eventQuery != ""
+		matchSpecified := matchQuery != ""
+		teamSpecified := teamQuery != ""
 
 		var realmID *int64
 		userRealmID, err := ihttp.GetRealmID(r)
@@ -23,10 +28,23 @@ func (s *Server) getReports() http.HandlerFunc {
 			realmID = &userRealmID
 		}
 
-		reports, err := s.Store.GetMatchTeamReportsForRealm(r.Context(), eventKey, matchKey, teamKey, realmID)
-		if err != nil {
-			ihttp.Error(w, http.StatusInternalServerError)
-			s.Logger.WithError(err).Error("getting reports")
+		var reports []store.Report
+		if eventSpecified && matchSpecified && teamSpecified {
+			reports, err = s.Store.GetMatchTeamReportsForRealm(r.Context(), eventQuery, matchQuery, teamQuery, realmID)
+			if err != nil {
+				ihttp.Error(w, http.StatusInternalServerError)
+				s.Logger.WithError(err).Error("getting reports")
+				return
+			}
+		} else if eventSpecified && teamSpecified {
+			reports, err = s.Store.GetEventTeamReportsForRealm(r.Context(), eventQuery, teamQuery, realmID)
+			if err != nil {
+				ihttp.Error(w, http.StatusInternalServerError)
+				s.Logger.WithError(err).Error("getting reports")
+				return
+			}
+		} else {
+			ihttp.Error(w, http.StatusBadRequest)
 			return
 		}
 
@@ -34,22 +52,13 @@ func (s *Server) getReports() http.HandlerFunc {
 	}
 }
 
-func (s *Server) putReport() http.HandlerFunc {
+func (s *Server) postReportHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		vars := mux.Vars(r)
-		eventKey := vars["eventKey"]
-		matchKey := vars["matchKey"]
-		teamKey := vars["teamKey"]
-
 		var report store.Report
 		if err := json.NewDecoder(r.Body).Decode(&report); err != nil {
 			ihttp.Error(w, http.StatusUnprocessableEntity)
 			return
 		}
-
-		report.EventKey = eventKey
-		report.MatchKey = matchKey
-		report.TeamKey = teamKey
 
 		reporterID, err := ihttp.GetSubject(r)
 		if err != nil {
@@ -66,18 +75,175 @@ func (s *Server) putReport() http.HandlerFunc {
 		}
 		report.RealmID = &realmID
 
-		created, err := s.Store.UpsertReport(r.Context(), report)
+		// make sure team is present at match, and the event is visible to user
+		present, err := s.Store.IsTeamPresentAtMatch(r.Context(), report.EventKey, report.MatchKey, report.TeamKey, &realmID)
+		if err != nil {
+			ihttp.Error(w, http.StatusInternalServerError)
+			s.Logger.WithError(err).Error("checking team at match")
+			return
+		}
+
+		if !present {
+			ihttp.Error(w, http.StatusNotFound)
+			return
+		}
+
+		created, id, err := s.Store.UpsertReport(r.Context(), report)
 		if err != nil {
 			ihttp.Error(w, http.StatusInternalServerError)
 			s.Logger.WithError(err).Error("upserting report")
 			return
 		}
 
+		var status int
 		if created {
-			w.WriteHeader(http.StatusCreated)
+			status = http.StatusCreated
 		} else {
-			w.WriteHeader(http.StatusNoContent)
+			status = http.StatusOK
 		}
+
+		ihttp.Respond(w, id, status)
+	}
+}
+
+func (s *Server) putReportHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id, err := strconv.ParseInt(mux.Vars(r)["id"], 10, 64)
+		if err != nil {
+			ihttp.Error(w, http.StatusBadRequest)
+			return
+		}
+
+		var report store.Report
+		if err := json.NewDecoder(r.Body).Decode(&report); err != nil {
+			ihttp.Error(w, http.StatusUnprocessableEntity)
+			return
+		}
+
+		roles := ihttp.GetRoles(r)
+
+		reporterID, err := ihttp.GetSubject(r)
+		if err != nil {
+			ihttp.Error(w, http.StatusForbidden)
+			return
+		}
+
+		var realmID int64
+		realmID, err = ihttp.GetRealmID(r)
+		if err != nil {
+			ihttp.Error(w, http.StatusForbidden)
+			return
+		}
+
+		oldReport, err := s.Store.GetReportByID(r.Context(), id)
+		if errors.Is(err, store.ErrNoResults{}) {
+			ihttp.Error(w, http.StatusNotFound)
+			return
+		} else if err != nil {
+			ihttp.Error(w, http.StatusInternalServerError)
+			s.Logger.WithError(err).Error("unable to retrieve report")
+			return
+		}
+
+		report.ID = id
+
+		if !roles.IsSuperAdmin && !roles.IsAdmin {
+			if report.ReporterID == nil || reporterID != *report.ReporterID ||
+				oldReport.ReporterID == nil || reporterID != *oldReport.ReporterID {
+				ihttp.Error(w, http.StatusForbidden)
+				return
+			}
+		} else {
+			if report.ReporterID != nil {
+				targetUser, err := s.Store.GetUserByID(r.Context(), *report.ReporterID)
+				if errors.Is(err, store.ErrNoResults{}) {
+					ihttp.Error(w, http.StatusNotFound)
+					return
+				} else if err != nil {
+					ihttp.Error(w, http.StatusInternalServerError)
+					s.Logger.WithError(err).Error("unable to retrieve user")
+					return
+				}
+
+				// report realm and reporter's realm must match if both specified
+				if report.RealmID != nil && targetUser.RealmID != *report.RealmID {
+					ihttp.Error(w, http.StatusBadRequest)
+					return
+				}
+
+				if !roles.IsSuperAdmin && targetUser.RealmID != realmID {
+					ihttp.Error(w, http.StatusForbidden)
+					return
+				}
+			}
+		}
+
+		if !roles.IsSuperAdmin {
+			if (report.RealmID != nil && realmID != *report.RealmID) ||
+				(oldReport.RealmID != nil && realmID != *oldReport.RealmID) {
+				ihttp.Error(w, http.StatusForbidden)
+				return
+			}
+		}
+
+		err = s.Store.UpdateReport(r.Context(), report)
+		if err != nil {
+			ihttp.Error(w, http.StatusInternalServerError)
+			s.Logger.WithError(err).Error("updating report")
+			return
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// deleteReportHandler returns a handler to delete a specific report.
+func (s *Server) deleteReportHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id, err := strconv.ParseInt(mux.Vars(r)["id"], 10, 64)
+		if err != nil {
+			ihttp.Error(w, http.StatusBadRequest)
+			return
+		}
+
+		roles := ihttp.GetRoles(r)
+		userRealmID, err := ihttp.GetRealmID(r)
+		if err != nil {
+			ihttp.Error(w, http.StatusForbidden)
+			return
+		}
+
+		userID, err := ihttp.GetSubject(r)
+		if err != nil {
+			ihttp.Error(w, http.StatusForbidden)
+			return
+		}
+
+		report, err := s.Store.GetReportByID(r.Context(), id)
+		if errors.Is(err, store.ErrNoResults{}) {
+			ihttp.Error(w, http.StatusNotFound)
+			return
+		} else if err != nil {
+			ihttp.Error(w, http.StatusInternalServerError)
+			s.Logger.WithError(err).Error("unable to retrieve report")
+			return
+		}
+
+		if !(roles.IsSuperAdmin) &&
+			!(roles.IsAdmin && report.RealmID != nil && userRealmID == *report.RealmID) &&
+			!(report.ReporterID != nil && userID == *report.ReporterID) {
+			ihttp.Error(w, http.StatusForbidden)
+			return
+		}
+
+		err = s.Store.DeleteReportByID(r.Context(), id)
+		if err != nil {
+			ihttp.Error(w, http.StatusInternalServerError)
+			s.Logger.WithError(err).Error("unable to retrieve report")
+			return
+		}
+
+		w.WriteHeader(http.StatusNoContent)
 	}
 }
 

--- a/internal/server/reports.go
+++ b/internal/server/reports.go
@@ -84,7 +84,7 @@ func (s *Server) postReportHandler() http.HandlerFunc {
 		}
 
 		if !present {
-			ihttp.Error(w, http.StatusNotFound)
+			ihttp.Error(w, http.StatusBadRequest)
 			return
 		}
 
@@ -157,7 +157,7 @@ func (s *Server) putReportHandler() http.HandlerFunc {
 			if report.ReporterID != nil {
 				targetUser, err := s.Store.GetUserByID(r.Context(), *report.ReporterID)
 				if errors.Is(err, store.ErrNoResults{}) {
-					ihttp.Error(w, http.StatusNotFound)
+					ihttp.Error(w, http.StatusBadRequest)
 					return
 				} else if err != nil {
 					ihttp.Error(w, http.StatusInternalServerError)

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -43,10 +43,12 @@ func (s *Server) registerRoutes() *mux.Router {
 	r.Handle("/events/{eventKey}/teams", s.eventTeamsHandler()).Methods(http.MethodGet)
 	r.Handle("/events/{eventKey}/teams/{teamKey}", s.eventTeamHandler()).Methods(http.MethodGet)
 
-	r.Handle("/events/{eventKey}/matches/{matchKey}/reports/{teamKey}", ihttp.ACL(s.getReports(), false, false, false)).Methods(http.MethodGet)
-	r.Handle("/events/{eventKey}/matches/{matchKey}/reports/{teamKey}", ihttp.ACL(s.putReport(), false, true, true)).Methods(http.MethodPut)
-
 	r.Handle("/events/{eventKey}/matches/{matchKey}/teams/{teamKey}/stats", s.matchTeamStats()).Methods(http.MethodGet)
+
+	r.Handle("/reports", ihttp.ACL(s.postReportHandler(), false, true, true)).Methods(http.MethodPost)
+	r.Handle("/reports", ihttp.ACL(s.getReportsHandler(), false, false, false)).Methods(http.MethodGet)
+	r.Handle("/reports/{id}", ihttp.ACL(s.putReportHandler(), false, true, true)).Methods(http.MethodPut)
+	r.Handle("/reports/{id}", ihttp.ACL(s.deleteReportHandler(), false, true, true)).Methods(http.MethodDelete)
 
 	r.Handle("/leaderboard", s.leaderboardHandler()).Methods(http.MethodGet)
 

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -45,8 +45,9 @@ func (s *Server) registerRoutes() *mux.Router {
 
 	r.Handle("/events/{eventKey}/matches/{matchKey}/teams/{teamKey}/stats", s.matchTeamStats()).Methods(http.MethodGet)
 
+	r.Handle("/reports", ihttp.ACL(s.reportsHandler(), false, false, false)).Methods(http.MethodGet)
 	r.Handle("/reports", ihttp.ACL(s.postReportHandler(), false, true, true)).Methods(http.MethodPost)
-	r.Handle("/reports", ihttp.ACL(s.getReportsHandler(), false, false, false)).Methods(http.MethodGet)
+	r.Handle("/reports/{id}", ihttp.ACL(s.reportHandler(), false, false, false)).Methods(http.MethodGet)
 	r.Handle("/reports/{id}", ihttp.ACL(s.putReportHandler(), false, true, true)).Methods(http.MethodPut)
 	r.Handle("/reports/{id}", ihttp.ACL(s.deleteReportHandler(), false, true, true)).Methods(http.MethodDelete)
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -54,3 +54,37 @@ func (s *Server) Run() error {
 	s.Logger.WithField("httpAddress", s.Listen).Info("serving http")
 	return httpServer.ListenAndServe()
 }
+
+type forbiddenError struct {
+	err error
+}
+
+func (f forbiddenError) Unwrap() error {
+	return f.err
+}
+
+func (f forbiddenError) Error() string {
+	return f.err.Error()
+}
+
+func (f forbiddenError) Is(target error) bool {
+	_, ok := target.(forbiddenError)
+	return ok
+}
+
+type badRequestError struct {
+	err error
+}
+
+func (e badRequestError) Unwrap() error {
+	return e.err
+}
+
+func (e badRequestError) Error() string {
+	return e.err.Error()
+}
+
+func (e badRequestError) Is(target error) bool {
+	_, ok := target.(badRequestError)
+	return ok
+}

--- a/internal/store/alliances.go
+++ b/internal/store/alliances.go
@@ -37,3 +37,25 @@ func (s *Service) AlliancesUpsertTx(ctx context.Context, tx *sqlx.Tx, eventKey, 
 
 	return nil
 }
+
+// IsTeamPresentAtMatch returns whether the specified team is on an alliance in the specified match
+func (s *Service) IsTeamPresentAtMatch(ctx context.Context, eventKey, matchKey, teamKey string, realmID *int64) (present bool, err error) {
+	err = s.db.QueryRowContext(ctx, `
+			SELECT EXISTS(
+				SELECT FROM alliances
+				LEFT JOIN events
+					ON events.key = alliances.event_key
+				WHERE
+					alliances.event_key = $1 AND
+					alliances.match_key = $2 AND
+					$3 = ANY(alliances.team_keys) AND
+					(events.realm_id IS NULL OR events.realm_id = $4)
+
+			)
+			`, eventKey, matchKey, teamKey, realmID).Scan(&present)
+	if err != nil {
+		return present, fmt.Errorf("unable to determine if team is present: %w", err)
+	}
+
+	return present, nil
+}


### PR DESCRIPTION
# Goal

Let (super)admins edit other users' reports. This includes moving those reports to different events/matches/teams, as a user may have submitted to the wrong team for a match, or been one match behind schedule, etc. Also includes changing the reporter/realm a report is associated with, could be useful when people use a guest account or similar, and would later like reports to be under their own account.

# Testing

Try submitting, editing, and deleting reports from different accounts, and across realms.

Closes #253, and closes #251